### PR TITLE
feat: create redash schema and user

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -82,6 +82,7 @@ def run_migrations_online():
         connection=connection,
         target_metadata=target_metadata,
         process_revision_directives=process_revision_directives,
+        version_table_schema=schema,
         **current_app.extensions["migrate"].configure_args
     )
 

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -96,9 +96,9 @@ def create_tables():
                 ),
             )
 
-        iam_db_uri = get_iam_auth_dburi()
-        grant_engine = sqlalchemy.engine.create_engine(iam_db_uri)
-        redash_user_grant(grant_engine, db.engine)
+            iam_db_uri = get_iam_auth_dburi()
+            grant_engine = sqlalchemy.engine.create_engine(iam_db_uri)
+            redash_user_grant(grant_engine, db.engine)
 
         _wait_for_db_connection(db)
 

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -1,6 +1,7 @@
 import time
 import os
 from urllib.parse import urlparse
+from pathlib import Path
 
 from click import argument, option
 from flask.cli import AppGroup
@@ -20,8 +21,8 @@ from redash.utils.configuration import ConfigurationContainer
 
 manager = AppGroup(help="Manage the database (create/drop tables. reencrypt data.).")
 
-DBIAM_USER = "assetdb"  # os.environ["REDASH_DBIAM_USER"]
-DBURI_TEMPLATE = "postgresql://{user}:{password}@assetdb.csowsmcthnij.us-east-2.rds.amazonaws.com:5432/assetdb"  # os.environ["REDASH_DATABASE_URL"]
+DBIAM_USER = os.environ["REDASH_DBIAM_USER"]
+DBURI_TEMPLATE = os.environ["REDASH_DATABASE_URL"]
 
 
 def get_db_auth_token(username, hostname, port):
@@ -31,6 +32,8 @@ def get_db_auth_token(username, hostname, port):
 
 
 def get_iam_auth_dsn(dburi, dbiam):
+    rds_pem = Path("/app/rds-combined-ca-bundle.pem")
+    print("FILE", rds_pem.is_file())
     db = urlparse(dburi)
     dsn = parse_dsn(dburi)
     dsn["user"] = dbiam

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -35,8 +35,8 @@ def get_iam_auth_dsn(dburi, dbiam):
     dsn = parse_dsn(dburi)
     dsn["user"] = dbiam
     dsn["password"] = get_db_auth_token(dbiam, db.hostname, db.port)
-    # dsn["sslmode"] = "prefer"
-    # dsn["sslrootcert"] = "/src/stacklet/assetdb/files/aws/rds-combined-ca-bundle.pem"
+    dsn["sslmode"] = "prefer"
+    dsn["sslrootcert"] = "/app/rds-combined-ca-bundle.pem"
     return dsn
 
 

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -44,6 +44,7 @@ def create_do_connect_handler(dburi, dbiam):
     def handler(dialect, conn_rec, cargs, cparams):
         dsn = parse_dsn(dburi)
         dsn = get_iam_auth_dsn(dburi, dbiam)
+        print(dsn)
         return psycopg2.connect(**dsn)
 
     return handler
@@ -63,7 +64,6 @@ def get_db(dburi, dbiam):
 
 def redash_user_grant(redash_engine):
     iam_engine = get_db(DBURI_TEMPLATE, DBIAM_USER)
-    print(iam_engine.url)
 
     username = redash_engine.url.username
     password = redash_engine.url.password

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -35,7 +35,7 @@ def get_iam_auth_dsn(dburi, dbiam):
     dsn = parse_dsn(dburi)
     dsn["user"] = dbiam
     dsn["password"] = get_db_auth_token(dbiam, db.hostname, db.port)
-    dsn["sslmode"] = "prefer"
+    dsn["sslmode"] = "require"
     dsn["sslrootcert"] = "/app/rds-combined-ca-bundle.pem"
     return dsn
 

--- a/redash/db/rds.py
+++ b/redash/db/rds.py
@@ -1,0 +1,80 @@
+import os
+from urllib.parse import urlparse
+
+import boto3
+import sqlalchemy
+
+import psycopg2
+from psycopg2.extensions import parse_dsn
+
+from redash import settings
+
+DBIAM_USER = os.getenv("REDASH_DBIAM_USER", "")
+DBURI_TEMPLATE = os.getenv("REDASH_DATABASE_URL", "")
+
+
+def get_db_auth_token(username, hostname, port):
+    return boto3.client("rds").generate_db_auth_token(
+        DBHostname=hostname, Port=port, DBUsername=username
+    )
+
+
+def get_iam_auth_dsn(dburi, dbiam):
+    db = urlparse(dburi)
+    dsn = parse_dsn(dburi)
+    dsn["user"] = dbiam
+    dsn["password"] = get_db_auth_token(dbiam, db.hostname, db.port)
+    dsn["sslmode"] = "verify-full"
+    dsn["sslrootcert"] = "/app/rds-combined-ca-bundle.pem"
+    return dsn
+
+
+def create_do_connect_handler(dburi, dbiam):
+    def handler(dialect, conn_rec, cargs, cparams):
+        dsn = parse_dsn(dburi)
+        dsn = get_iam_auth_dsn(dburi, dbiam)
+        print(dsn)
+        return psycopg2.connect(**dsn)
+
+    return handler
+
+
+def get_db(dburi, dbiam):
+    if "postgresql" in dburi:
+        engine = sqlalchemy.create_engine("postgresql://")
+        sqlalchemy.event.listen(
+            engine, "do_connect", create_do_connect_handler(dburi, dbiam)
+        )
+        return engine
+    engine = sqlalchemy.create_engine(dburi)
+    return engine
+
+
+def redash_user_grant(redash_engine):
+    print("found IAM user setting")
+    iam_engine = get_db(DBURI_TEMPLATE, DBIAM_USER)
+
+    username = redash_engine.url.username
+    password = redash_engine.url.password
+
+    with iam_engine.connect() as conn:
+        print(f"creating schema {settings.SQLALCHEMY_DATABASE_SCHEMA}")
+        conn.execute(
+            f"CREATE SCHEMA IF NOT EXISTS {settings.SQLALCHEMY_DATABASE_SCHEMA}"
+        )
+        result = conn.execute(f"SELECT 1 FROM pg_roles WHERE rolname='{username}'")
+        if not result.fetchone():
+            print(f"creating user {username}")
+            conn.execute(f"CREATE ROLE {username} WITH PASSWORD '{password}' LOGIN")
+        print(
+            f"granting all privileges on schema, tables, sequences in {settings.SQLALCHEMY_DATABASE_SCHEMA} for {username}"
+        )
+        conn.execute(
+            f"GRANT ALL PRIVILEGES ON SCHEMA {settings.SQLALCHEMY_DATABASE_SCHEMA} TO {username}"
+        )
+        conn.execute(
+            f"GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {settings.SQLALCHEMY_DATABASE_SCHEMA} TO {username}"
+        )
+        conn.execute(
+            f"GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {settings.SQLALCHEMY_DATABASE_SCHEMA} TO {username}"
+        )


### PR DESCRIPTION
Support creating schema and redash user during redash create phase.

### Why we need this
Redash does not have the ability to perform IAM auth for RDS instances. We also do not want redash connecting at the "root" RDS user with the ability to modify or change the AssetDB public schema.

The goal of this PR is to use the "root" user via IAM auth token to create the redash schema, a redash role, and grant the proper permissions to that user, which when then be used as credentials for the AssetDB Source in redash.