### PR TITLE
fix: create after_request event handler for cors

### DIFF
--- a/redash/handlers/__init__.py
+++ b/redash/handlers/__init__.py
@@ -1,11 +1,13 @@
+import os
 from flask import jsonify
 from flask_login import login_required
 
 from redash.handlers.api import api
-from redash.handlers.base import routes
+from redash.handlers.base import routes, add_cors_headers
 from redash.monitor import get_status
 from redash.permissions import require_super_admin
 from redash.security import talisman
+from redash.settings.helpers import set_from_string
 
 
 @routes.route("/ping", methods=["GET"])
@@ -35,3 +37,12 @@ def init_app(app):
 
     app.register_blueprint(routes)
     api.init_app(app)
+
+    @app.after_request
+    def add_header(response):
+        ACCESS_CONTROL_ALLOW_ORIGIN = set_from_string(
+            os.environ.get("REDASH_CORS_ACCESS_CONTROL_ALLOW_ORIGIN", "")
+        )
+        if len(ACCESS_CONTROL_ALLOW_ORIGIN) > 0:
+            add_cors_headers(response.headers)
+        return response

--- a/redash/handlers/dashboards.py
+++ b/redash/handlers/dashboards.py
@@ -2,14 +2,13 @@ from flask import request, url_for
 from funcy import project, partial
 
 from flask_restful import abort
-from redash import models, settings
+from redash import models
 from redash.handlers.base import (
     BaseResource,
     get_object_or_404,
     paginate,
     filter_by_tags,
     order_results as _order_results,
-    add_cors_headers,
 )
 from redash.permissions import (
     can_modify,
@@ -89,10 +88,6 @@ class DashboardListResource(BaseResource):
             )
         else:
             self.record_event({"action": "list", "object_type": "dashboard"})
-
-        if len(settings.ACCESS_CONTROL_ALLOW_ORIGIN) > 0:
-            response["headers"] = response.get("headers", {})
-            add_cors_headers(response.get("headers"))
 
         return response
 
@@ -217,10 +212,6 @@ class DashboardResource(BaseResource):
         self.record_event(
             {"action": "view", "object_id": dashboard.id, "object_type": "dashboard"}
         )
-
-        if len(settings.ACCESS_CONTROL_ALLOW_ORIGIN) > 0:
-            response["headers"] = response.get("headers", {})
-            add_cors_headers(response.get("headers"))
 
         return response
 


### PR DESCRIPTION
Add CORS support to all API requests in redash. This is needed for better embedding support.