### PR TITLE
feat: make jwt user claim key configurable (PLATFORM-2074)

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -192,10 +192,11 @@ def jwt_token_load_user_from_request(request):
     if not payload:
         return
 
+    email = payload[org_settings["auth_jwt_auth_user_claim"]]
     try:
-        user = models.User.get_by_email_and_org(payload["email"], org)
+        user = models.User.get_by_email_and_org(email, org)
     except models.NoResultFound:
-        user = create_and_login_user(current_org, payload["email"], payload["email"])
+        user = create_and_login_user(current_org, email, email)
 
     return user
 

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -182,7 +182,7 @@ def jwt_token_load_user_from_request(request):
         payload, token_is_valid = jwt_auth.verify_jwt_token(
             jwt_token,
             expected_issuer=org_settings["auth_jwt_auth_issuer"],
-            expected_audience=org_settings["auth_jwt_auth_audience"],
+            expected_audience=org_settings["auth_jwt_auth_audience"] or None,
             algorithms=org_settings["auth_jwt_auth_algorithms"],
             public_certs_url=org_settings["auth_jwt_auth_public_certs_url"],
         )

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -183,6 +183,7 @@ def jwt_token_load_user_from_request(request):
             jwt_token,
             expected_issuer=org_settings["auth_jwt_auth_issuer"],
             expected_audience=org_settings["auth_jwt_auth_audience"] or None,
+            expected_client_id=org_settings["auth_jwt_auth_client_id"] or None,
             algorithms=org_settings["auth_jwt_auth_algorithms"],
             public_certs_url=org_settings["auth_jwt_auth_public_certs_url"],
         )

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -37,7 +37,7 @@ get_public_keys.key_cache = {}
 
 
 def verify_jwt_token(
-    jwt_token, expected_issuer, expected_audience, algorithms, public_certs_url
+    jwt_token, expected_issuer, expected_audience, expected_client_id, algorithms, public_certs_url
 ):
     # https://developers.cloudflare.com/access/setting-up-access/validate-jwt-tokens/
     # https://cloud.google.com/iap/docs/signed-headers-howto
@@ -59,6 +59,9 @@ def verify_jwt_token(
             issuer = payload["iss"]
             if issuer != expected_issuer:
                 raise Exception("Wrong issuer: {}".format(issuer))
+            client_id = payload.get("client_id")
+            if expected_client_id and expected_client_id != client_id:
+                raise Exception("Wrong client_id: {}".format(client_id))
             valid_token = True
             break
         except Exception as e:

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -34,6 +34,7 @@ JWT_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_JWT_LOGIN_ENABLED", "fa
 JWT_AUTH_ISSUER = os.environ.get("REDASH_JWT_AUTH_ISSUER", "")
 JWT_AUTH_PUBLIC_CERTS_URL = os.environ.get("REDASH_JWT_AUTH_PUBLIC_CERTS_URL", "")
 JWT_AUTH_AUDIENCE = os.environ.get("REDASH_JWT_AUTH_AUDIENCE", "")
+JWT_AUTH_CLIENT_ID = os.environ.get("REDASH_JWT_AUTH_CLIENT_ID", "")
 JWT_AUTH_ALGORITHMS = os.environ.get(
     "REDASH_JWT_AUTH_ALGORITHMS", "HS256,RS256,ES256"
 ).split(",")
@@ -71,6 +72,7 @@ settings = {
     "auth_jwt_auth_issuer": JWT_AUTH_ISSUER,
     "auth_jwt_auth_public_certs_url": JWT_AUTH_PUBLIC_CERTS_URL,
     "auth_jwt_auth_audience": JWT_AUTH_AUDIENCE,
+    "auth_jwt_auth_client_id": JWT_AUTH_CLIENT_ID,
     "auth_jwt_auth_algorithms": JWT_AUTH_ALGORITHMS,
     "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
     "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -39,6 +39,7 @@ JWT_AUTH_ALGORITHMS = os.environ.get(
 ).split(",")
 JWT_AUTH_COOKIE_NAME = os.environ.get("REDASH_JWT_AUTH_COOKIE_NAME", "")
 JWT_AUTH_HEADER_NAME = os.environ.get("REDASH_JWT_AUTH_HEADER_NAME", "")
+JWT_AUTH_USER_CLAIM = os.environ.get("REDASH_JWT_USER_CLAIM", "email")
 
 FEATURE_SHOW_PERMISSIONS_CONTROL = parse_boolean(
     os.environ.get("REDASH_FEATURE_SHOW_PERMISSIONS_CONTROL", "false")
@@ -73,6 +74,7 @@ settings = {
     "auth_jwt_auth_algorithms": JWT_AUTH_ALGORITHMS,
     "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
     "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,
+    "auth_jwt_auth_user_claim": JWT_AUTH_USER_CLAIM,
     "feature_show_permissions_control": FEATURE_SHOW_PERMISSIONS_CONTROL,
     "send_email_on_failed_scheduled_queries": SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES,
     "hide_plotly_mode_bar": HIDE_PLOTLY_MODE_BAR,


### PR DESCRIPTION
Makes the JWT support more flexible by both allowing the claim which contains the user info configurable, rather than being hard-coded to `email`, and adding support for `client_id` claim validation, such as is used by Cognito.

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

## Related Tickets & Documents
https://stacklet.atlassian.net/browse/PLATFORM-2074
https://github.com/stacklet/platform-ui/pull/1007
https://github.com/stacklet/redash-infra/pull/32
https://github.com/stacklet/platform/pull/1163

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
