### PR TITLE
feat: support external login redirection URL (PLATFORM-2411)

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -178,20 +178,20 @@ def jwt_token_load_user_from_request(request):
     else:
         return None
 
-    if jwt_token:
-        payload, token_is_valid = jwt_auth.verify_jwt_token(
-            jwt_token,
-            expected_issuer=org_settings["auth_jwt_auth_issuer"],
-            expected_audience=org_settings["auth_jwt_auth_audience"] or None,
-            expected_client_id=org_settings["auth_jwt_auth_client_id"] or None,
-            algorithms=org_settings["auth_jwt_auth_algorithms"],
-            public_certs_url=org_settings["auth_jwt_auth_public_certs_url"],
-        )
-        if not token_is_valid:
-            raise Unauthorized("Invalid JWT token")
+    if not jwt_token:
+        return None
 
-    if not payload:
-        return
+    payload, valid_token = jwt_auth.verify_jwt_token(
+        jwt_token,
+        expected_issuer=org_settings["auth_jwt_auth_issuer"],
+        expected_audience=org_settings["auth_jwt_auth_audience"] or None,
+        expected_client_id=org_settings["auth_jwt_auth_client_id"] or None,
+        algorithms=org_settings["auth_jwt_auth_algorithms"],
+        public_certs_url=org_settings["auth_jwt_auth_public_certs_url"],
+    )
+
+    if not valid_token:
+        return None
 
     email = payload[org_settings["auth_jwt_auth_user_claim"]]
     try:
@@ -225,7 +225,10 @@ def redirect_to_login():
         response.status_code = 404
         return response
 
-    login_url = get_login_url(next=request.url, external=False)
+    if org_settings["auth_jwt_login_enabled"] and org_settings["auth_jwt_auth_login_url"]:
+        login_url = org_settings["auth_jwt_auth_login_url"]
+    else:
+        login_url = get_login_url(next=request.url, external=False)
 
     return redirect(login_url)
 

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -2,6 +2,14 @@ import logging
 import jwt
 import requests
 import simplejson
+from jwt.exceptions import (
+    PyJWTError,
+    InvalidTokenError,
+    MissingRequiredClaimError,
+    ExpiredSignatureError,
+)
+
+from redash.settings.organization import settings as org_settings
 
 logger = logging.getLogger("jwt_auth")
 
@@ -50,7 +58,7 @@ def verify_jwt_token(
 
     valid_token = False
     payload = None
-    for key in keys:
+    for i, key in enumerate(keys):
         try:
             # decode returns the claims which has the email if you need it
             payload = jwt.decode(
@@ -58,12 +66,18 @@ def verify_jwt_token(
             )
             issuer = payload["iss"]
             if issuer != expected_issuer:
-                raise Exception("Wrong issuer: {}".format(issuer))
+                raise InvalidTokenError("Wrong issuer: {}".format(issuer))
             client_id = payload.get("client_id")
             if expected_client_id and expected_client_id != client_id:
-                raise Exception("Wrong client_id: {}".format(client_id))
+                raise InvalidTokenError("Wrong client_id: {}".format(client_id))
+            user_claim = org_settings["auth_jwt_auth_user_claim"]
+            if not payload.get(user_claim):
+                raise MissingRequiredClaimError(user_claim)
             valid_token = True
             break
+        except PyJWTError as e:
+            logging.info("Rejecting JWT token for key %d: %s", i, e)
         except Exception as e:
-            logging.exception(e)
+            logging.exception("Error processing JWT token: %s", e)
+            break
     return payload, valid_token

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -40,7 +40,8 @@ JWT_AUTH_ALGORITHMS = os.environ.get(
 ).split(",")
 JWT_AUTH_COOKIE_NAME = os.environ.get("REDASH_JWT_AUTH_COOKIE_NAME", "")
 JWT_AUTH_HEADER_NAME = os.environ.get("REDASH_JWT_AUTH_HEADER_NAME", "")
-JWT_AUTH_USER_CLAIM = os.environ.get("REDASH_JWT_USER_CLAIM", "email")
+JWT_AUTH_USER_CLAIM = os.environ.get("REDASH_JWT_AUTH_USER_CLAIM", "email")
+JWT_AUTH_LOGIN_URL = os.environ.get("REDASH_JWT_AUTH_LOGIN_URL", "")
 
 FEATURE_SHOW_PERMISSIONS_CONTROL = parse_boolean(
     os.environ.get("REDASH_FEATURE_SHOW_PERMISSIONS_CONTROL", "false")
@@ -77,6 +78,7 @@ settings = {
     "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
     "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,
     "auth_jwt_auth_user_claim": JWT_AUTH_USER_CLAIM,
+    "auth_jwt_auth_login_url": JWT_AUTH_LOGIN_URL,
     "feature_show_permissions_control": FEATURE_SHOW_PERMISSIONS_CONTROL,
     "send_email_on_failed_scheduled_queries": SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES,
     "hide_plotly_mode_bar": HIDE_PLOTLY_MODE_BAR,


### PR DESCRIPTION
Add support for sending failed authentication to an external URL when using JWT.

Part of [PLATFORM-2411](https://stacklet.atlassian.net/browse/PLATFORM-2411)

This is deployed on my sandbox and can be tested by going to https://redash.cory.sandbox.stacklet.dev/ and confirming the redirect, then logging in with the `stacklet-admin` user from 1password and confirming the post-login re-redirect.