### PR TITLE
feat: reflect stacklet admin in redash (PLATFORM-2545)

### DIFF
--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -52,7 +52,12 @@ def verify_jwt_token(
     # Loop through the keys since we can't pass the key set to the decoder
     keys = get_public_keys(public_certs_url)
 
-    key_id = jwt.get_unverified_header(jwt_token).get("kid", "")
+    try:
+        key_id = jwt.get_unverified_header(jwt_token).get("kid", "")
+    except PyJWTError as e:
+        logger.info("Ignoring invalid JWT token: %s", e)
+        return None, False
+
     if key_id and isinstance(keys, dict):
         keys = [keys.get(key_id)]
 
@@ -76,8 +81,8 @@ def verify_jwt_token(
             valid_token = True
             break
         except PyJWTError as e:
-            logging.info("Rejecting JWT token for key %d: %s", i, e)
+            logger.info("Rejecting JWT token for key %d: %s", i, e)
         except Exception as e:
-            logging.exception("Error processing JWT token: %s", e)
+            logger.exception("Error processing JWT token: %s", e)
             break
     return payload, valid_token


### PR DESCRIPTION
Now that the JWT token includes the stacklet permissions, we can add or remove the Redash admin group based on whether the user is an admin (has `system: write` permission) in Stacklet.