### PR TITLE
fix: find identity from multiple fields in token (PLATFORM-2688)

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -197,7 +197,7 @@ def jwt_token_load_user_from_request(request):
     if not valid_token:
         return None
 
-    email = payload[org_settings["auth_jwt_auth_user_claim"]]
+    email = payload["identity"]
     try:
         user = models.User.get_by_email_and_org(email, org)
     except models.NoResultFound:

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -183,7 +183,7 @@ def jwt_token_load_user_from_request(request):
         return None
 
     try:
-        payload, valid_token = jwt_auth.verify_jwt_token(
+        payload, identity, valid_token = jwt_auth.verify_jwt_token(
             jwt_token,
             expected_issuer=org_settings["auth_jwt_auth_issuer"],
             expected_audience=org_settings["auth_jwt_auth_audience"] or None,
@@ -197,7 +197,8 @@ def jwt_token_load_user_from_request(request):
     if not valid_token:
         return None
 
-    email = payload["identity"]
+    # it might actually be a username or something, but it doesn't actually matter
+    email = identity
     try:
         user = models.User.get_by_email_and_org(email, org)
     except models.NoResultFound:

--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -97,8 +97,6 @@ def verify_jwt_token(
                 raise InvalidTokenError(
                     "Unable to determine identity (missing email, username, or other identifier)"
                 )
-            # Ensure identity is in a consistent place, regardless of where we found it.
-            payload["identity"] = identity
             valid_token = True
             break
         except InvalidTokenError as e:
@@ -109,4 +107,4 @@ def verify_jwt_token(
         except Exception as e:
             logger.exception("Error processing JWT token: %s", e)
             raise InvalidTokenError("Error processing token") from e
-    return payload, valid_token
+    return payload, identity, valid_token

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -40,7 +40,6 @@ JWT_AUTH_ALGORITHMS = os.environ.get(
 ).split(",")
 JWT_AUTH_COOKIE_NAME = os.environ.get("REDASH_JWT_AUTH_COOKIE_NAME", "")
 JWT_AUTH_HEADER_NAME = os.environ.get("REDASH_JWT_AUTH_HEADER_NAME", "")
-JWT_AUTH_USER_CLAIM = os.environ.get("REDASH_JWT_AUTH_USER_CLAIM", "email")
 JWT_AUTH_LOGIN_URL = os.environ.get("REDASH_JWT_AUTH_LOGIN_URL", "")
 
 FEATURE_SHOW_PERMISSIONS_CONTROL = parse_boolean(
@@ -77,7 +76,6 @@ settings = {
     "auth_jwt_auth_algorithms": JWT_AUTH_ALGORITHMS,
     "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
     "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,
-    "auth_jwt_auth_user_claim": JWT_AUTH_USER_CLAIM,
     "auth_jwt_auth_login_url": JWT_AUTH_LOGIN_URL,
     "feature_show_permissions_control": FEATURE_SHOW_PERMISSIONS_CONTROL,
     "send_email_on_failed_scheduled_queries": SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES,


### PR DESCRIPTION
Depending on the identity provider's configuration, the email address (identity) might be present in several different fields. Add logic to be more forgiving of where it is collected from.

Fixes [PLATFORM-2688](https://stacklet.atlassian.net/browse/PLATFORM-2688)