### PR TITLE
fix: handle expired tokens properly

### DIFF
--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -99,11 +99,15 @@ def verify_jwt_token(
                 )
             valid_token = True
             break
+        except ExpiredSignatureError as e:
+            logger.info("Rejecting expired JWT token: %s", e)
+            continue
         except InvalidTokenError as e:
             logger.info("Rejecting invalid JWT token: %s", e)
             raise
         except PyJWTError as e:
             logger.info("Rejecting JWT token for key %d: %s", i, e)
+            continue
         except Exception as e:
             logger.exception("Error processing JWT token: %s", e)
             raise InvalidTokenError("Error processing token") from e


### PR DESCRIPTION
In PR #31, invalid token errors were changed to surface rather than be ignored. However, since expired tokens weren't handled separately, they were inadvertently included and surfaced as errors when that specific case of "invalid" should actually just be treated as unauthorized (i.e., ignored) and redirected to the Console to be replaced / updated.