### PR TITLE
fix: fix js error when query schedule includes a time (ENG-859)

### DIFF
--- a/client/app/lib/utils.js
+++ b/client/app/lib/utils.js
@@ -47,11 +47,16 @@ export function formatDate(value) {
 
 export function localizeTime(time) {
   const [hrs, mins] = time.split(":");
+  // moment.locale() called with no param returns a locale ID string,
+  // but when called with a locale ID string it returns a date value.
+  // Call it first with no param to get the default locale ID and then
+  // explicitly pass that in to avoid a type error below.
+  const locale = moment.locale() || "en";
   return moment
     .utc()
     .hour(hrs)
     .minute(mins)
-    .locale()
+    .locale(locale)
     .format("HH:mm");
 }
 


### PR DESCRIPTION
Not sure how we haven't hit this before, but it appears that having a query with a schedule value detailed enough to include a time component rather than just a weekday triggers a bug in the moment date library which blows up the Redash UI. This works around it to avoid that error.

Fixes: [ENG-859](https://stacklet.atlassian.net/browse/ENG-859)