### PR TITLE
fix(hotfix): cherry-pick in js lib time parse bug fix (DO NOT MERGE)

### DIFF
--- a/client/app/lib/utils.js
+++ b/client/app/lib/utils.js
@@ -47,11 +47,16 @@ export function formatDate(value) {
 
 export function localizeTime(time) {
   const [hrs, mins] = time.split(":");
+  // moment.locale() called with no param returns a locale ID string,
+  // but when called with a locale ID string it returns a date value.
+  // Call it first with no param to get the default locale ID and then
+  // explicitly pass that in to avoid a type error below.
+  const locale = moment.locale() || "en";
   return moment
     .utc()
     .hour(hrs)
     .minute(mins)
-    .locale()
+    .locale(locale)
     .format("HH:mm");
 }
 


### PR DESCRIPTION
Pulls in the fix from #34 based against the redash commit (b96dc9b11782044fd53d52d5a4d2d9535d10d523) currently deployed for Avalara. (PR just for review purpose; DO NOT MERGE)