### PR TITLE
fix: add a to to the server side of gunicorn

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -32,7 +32,8 @@ server() {
   # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
   MAX_REQUESTS=${MAX_REQUESTS:-1000}
   MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
-  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER
+  TIMEOUT=${GUNICORN_TIMEOUT:-300}
+  exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER --timeout $TIMEOUT
 }
 
 create_db() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
 Add GUNICORN_TIMEOUT variable to set the TO on the gunicorn server and prevent large dataset from breaking cached_queries

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [X] Other

## Description

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
