### PR TITLE
chore: improve debugging for non-running query refresh job

### DIFF
--- a/redash/cli/rq.py
+++ b/redash/cli/rq.py
@@ -18,6 +18,7 @@ from redash.tasks import (
     rq_scheduler,
     schedule_periodic_jobs,
     periodic_job_definitions,
+    check_periodic_jobs,
 )
 from redash.worker import default_queues
 
@@ -75,12 +76,15 @@ class WorkerHealthcheck(base.BaseCheck):
         total_jobs_in_watched_queues = sum([len(q.jobs) for q in worker.queues])
         has_nothing_to_do = total_jobs_in_watched_queues == 0
 
-        is_healthy = is_busy or seen_lately or has_nothing_to_do
+        pjobs_ok, num_pjobs, num_missing_pjobs = check_periodic_jobs()
+
+        is_healthy = (is_busy or seen_lately or has_nothing_to_do) and pjobs_ok
 
         self._log(
             "Worker %s healthcheck: Is busy? %s. "
             "Seen lately? %s (%d seconds ago). "
             "Has nothing to do? %s (%d jobs in watched queues). "
+            "Periodic jobs ok? %s (%s missing of %s). "
             "==> Is healthy? %s",
             worker.key,
             is_busy,
@@ -88,6 +92,9 @@ class WorkerHealthcheck(base.BaseCheck):
             time_since_seen.seconds,
             has_nothing_to_do,
             total_jobs_in_watched_queues,
+            pjobs_ok,
+            num_missing_pjobs,
+            num_pjobs,
             is_healthy,
         )
 

--- a/redash/tasks/__init__.py
+++ b/redash/tasks/__init__.py
@@ -16,7 +16,12 @@ from .queries import (
 from .alerts import check_alerts_for_query
 from .failure_report import send_aggregated_errors
 from .worker import Worker, Queue, Job
-from .schedule import rq_scheduler, schedule_periodic_jobs, periodic_job_definitions
+from .schedule import (
+    rq_scheduler,
+    schedule_periodic_jobs,
+    periodic_job_definitions,
+    check_periodic_jobs,
+)
 
 from redash import rq_redis_connection
 from rq.connections import push_connection, pop_connection

--- a/redash/tasks/schedule.py
+++ b/redash/tasks/schedule.py
@@ -112,11 +112,18 @@ def schedule_periodic_jobs(jobs):
         job for job in job_definitions if job_id(job) not in rq_scheduler
     ]
 
+    logger.info("Current jobs: %s", ", ".join([
+        job.func_name.rsplit('.', 1)[-1]
+        for job in rq_scheduler.get_jobs()
+    ]))
+
     for job in jobs_to_clean_up:
         logger.info("Removing %s (%s) from schedule.", job.id, job.func_name)
         rq_scheduler.cancel(job)
         job.delete()
 
+    if not jobs_to_schedule:
+        logger.info("No jobs to schedule")
     for job in jobs_to_schedule:
         logger.info(
             "Scheduling %s (%s) with interval %s.",
@@ -125,3 +132,17 @@ def schedule_periodic_jobs(jobs):
             job.get("interval"),
         )
         schedule(job)
+
+
+def check_periodic_jobs():
+    job_definitions = [prep(job) for job in periodic_job_definitions()]
+    missing_jobs = [
+        job["func"].__name__
+        for job in job_definitions
+        if job_id(job) not in rq_scheduler
+    ]
+    if not job_definitions:
+        logger.warn("No periodic jobs defined")
+    if missing_jobs:
+        logger.warn("Missing periodic jobs: %s", ", ".join(missing_jobs))
+    return job_definitions and not missing_jobs, len(job_definitions), len(missing_jobs)


### PR DESCRIPTION
We have repeatedly seen the periodic job used to refresh queries end up not started with no visibility into why. There have also been red-herring tracebacks in the logs for non-error conditions (attempting to refresh the schema for Query Result data sources) which wasted time. This attempts to increase the visibility in the logs when the job doesn't get scheduled.