### PR TITLE
feat: health check for scheduler (ENG-2154)

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -4,7 +4,7 @@ set -e
 scheduler() {
   echo "Starting RQ scheduler..."
 
-  exec /app/manage.py rq scheduler
+  exec supervisord -c scheduler.conf
 }
 
 dev_scheduler() {

--- a/scheduler.conf
+++ b/scheduler.conf
@@ -9,10 +9,10 @@ file = /tmp/supervisor.sock
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
-[program:worker]
-command=./manage.py rq worker %(ENV_QUEUES)s
+[program:scheduler]
+command=./manage.py rq scheduler
 process_name=%(program_name)s-%(process_num)s
-numprocs=%(ENV_WORKERS_COUNT)s
+numprocs=1
 directory=/app
 stopsignal=TERM
 autostart=true
@@ -23,9 +23,9 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
-[eventlistener:worker_healthcheck]
+[eventlistener:scheduler_healthcheck]
 serverurl=AUTO
-command=./manage.py rq worker_healthcheck
+command=./manage.py rq scheduler_healthcheck
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
PR #42 added the check for expected periodic jobs to the worker health check, but that doesn't actually help because it restarts the worker process rather than the scheduler process. This creates a health check for the scheduler and moves the periodic jobs check to that. Switching the scheduler to use supervisord like the worker will likely also make it more resilient to things like Redis reboots / hiccups.

Fixes: [ENG-2154](https://stacklet.atlassian.net/browse/ENG-2154)

[ENG-2154]: https://stacklet.atlassian.net/browse/ENG-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ