### PR TITLE
feat: add db_role to Users and QueryResults models (ENG-2473, ENG-2475)

### DIFF
--- a/migrations/versions/a3a44a6c0dec_add_db_role.py
+++ b/migrations/versions/a3a44a6c0dec_add_db_role.py
@@ -1,4 +1,4 @@
-"""Add user db_role column.
+"""Add db_role column to Users and QueryResults.
 
 Revision ID: a3a44a6c0dec
 Revises: 89bc7873a3e0
@@ -25,7 +25,16 @@ def upgrade():
             nullable=True,
         ),
     )
+    op.add_column(
+        "query_results",
+        sa.Column(
+            "db_role",
+            sa.String(128),
+            nullable=True,
+        ),
+    )
 
 
 def downgrade():
     op.drop_column("users", "db_role")
+    op.drop_column("query_results", "db_role")

--- a/migrations/versions/a3a44a6c0dec_add_user_db_role.py
+++ b/migrations/versions/a3a44a6c0dec_add_user_db_role.py
@@ -1,0 +1,31 @@
+"""Add user db_role column.
+
+Revision ID: a3a44a6c0dec
+Revises: 89bc7873a3e0
+Create Date: 2023-08-04 17:47:29.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a3a44a6c0dec"
+down_revision = "89bc7873a3e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column(
+            "db_role",
+            sa.String(128),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("users", "db_role")

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -219,6 +219,11 @@ def jwt_token_load_user_from_request(request):
                 user_groups.discard("admin")
             user.update_group_assignments(user_groups)
 
+    db_role = payload.get("stacklet:db_role") or None  # force None instead of empty string, JIC
+    if db_role != user.db_role:
+        user.db_role = db_role
+        models.db.session.commit()
+
     return user
 
 

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -35,9 +35,12 @@ def is_db_empty():
     engine = get_env_db()
     db._engine = engine
 
+    schema = db.metadata.schema
     extant_tables = set(sqlalchemy.inspect(engine).get_table_names())
-    redash_tables = set(db.metadata.tables)
-    return len(redash_tables.intersection(extant_tables)) == 0
+    redash_tables = set(table.lstrip(f"{schema}.") for table in db.metadata.tables)
+    num_missing = (redash_tables - redash_tables.intersection(extant_tables))
+    print(f"Checking schema {schema} for tables {redash_tables}: found {extant_tables} (missing {num_missing})")
+    return num_missing == len(redash_tables)
 
 
 def load_extensions(db):

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -2,7 +2,7 @@ import time
 
 from click import argument, option
 from flask.cli import AppGroup
-from flask_migrate import stamp
+from flask_migrate import stamp, upgrade
 import sqlalchemy
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.sql import select
@@ -38,7 +38,7 @@ def is_db_empty():
     schema = db.metadata.schema
     extant_tables = set(sqlalchemy.inspect(engine).get_table_names())
     redash_tables = set(table.lstrip(f"{schema}.") for table in db.metadata.tables)
-    num_missing = (redash_tables - redash_tables.intersection(extant_tables))
+    num_missing = len(redash_tables - redash_tables.intersection(extant_tables))
     print(f"Checking schema {schema} for tables {redash_tables}: found {extant_tables} (missing {num_missing})")
     return num_missing == len(redash_tables)
 
@@ -80,7 +80,8 @@ def create_tables():
         # Need to mark current DB as up to date
         stamp()
     else:
-        print("existing redash tables detected, exiting")
+        print("existing redash tables detected, upgrading instead")
+        upgrade()
 
 
 @manager.command()

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -331,6 +331,7 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
     _data = Column("data", db.Text)
     runtime = Column(postgresql.DOUBLE_PRECISION)
     retrieved_at = Column(db.DateTime(True))
+    db_role = Column(db.String(128), nullable=True)
 
     __tablename__ = "query_results"
 
@@ -346,6 +347,7 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
             "data_source_id": self.data_source_id,
             "runtime": self.runtime,
             "retrieved_at": self.retrieved_at,
+            "db_role": self.db_role,
         }
 
     @classmethod
@@ -380,7 +382,7 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
 
     @classmethod
     def store_result(
-        cls, org, data_source, query_hash, query, data, run_time, retrieved_at
+        cls, org, data_source, query_hash, query, data, run_time, retrieved_at, db_role
     ):
         query_result = cls(
             org_id=org,
@@ -389,6 +391,7 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
             runtime=run_time,
             data_source=data_source,
             retrieved_at=retrieved_at,
+            db_role=db_role,
             data=data,
         )
 

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -91,6 +91,7 @@ class User(
         "groups", MutableList.as_mutable(postgresql.ARRAY(key_type("Group"))), nullable=True
     )
     api_key = Column(db.String(40), default=lambda: generate_token(40), unique=True)
+    db_role = Column(db.String(128), nullable=True)
 
     disabled_at = Column(db.DateTime(True), default=None, nullable=True)
     details = Column(
@@ -162,6 +163,9 @@ class User(
 
         if with_api_key:
             d["api_key"] = self.api_key
+
+        if self.db_role:
+            d["db_role"] = self.db_role
 
         return d
 
@@ -393,6 +397,8 @@ class AccessPermission(GFKBase, db.Model):
 
 
 class AnonymousUser(AnonymousUserMixin, PermissionsCheckMixin):
+    db_role = None
+
     @property
     def permissions(self):
         return []
@@ -413,6 +419,7 @@ class ApiUser(UserMixin, PermissionsCheckMixin):
             self.object = api_key.object
         self.group_ids = groups
         self.org = org
+        self.db_role = None
 
     def __repr__(self):
         return "<{}>".format(self.name)

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -252,7 +252,7 @@ class QueryExecutor(object):
     def _log_progress(self, state):
         logger.info(
             "job=execute_query state=%s query_hash=%s type=%s ds_id=%d "
-            "job_id=%s queue=%s query_id=%s username=%s",
+            "job_id=%s queue=%s query_id=%s username=%s db_role=%s",
             state,
             self.query_hash,
             self.data_source.type,
@@ -261,6 +261,7 @@ class QueryExecutor(object):
             self.metadata.get("Queue", "unknown"),
             self.metadata.get("query_id", "unknown"),
             self.metadata.get("Username", "unknown"),
+            self.user.db_role,
         )
 
     def _load_data_source(self):

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -228,6 +228,7 @@ class QueryExecutor(object):
                 data,
                 run_time,
                 utcnow(),
+                self.user.db_role,
             )
 
             updated_query_ids = models.Query.update_latest_result(query_result)


### PR DESCRIPTION
Part of the Row Level Security (RLS) changes.

Tested on my sandbox and confirmed that the `db_role` is available to the query context (via manual forcing in the users table).  I did confirm that the missing `stacklet:db_role` in the JWT token clears out the `db_role` in the DB, as expected. Fully confirming that it's set properly will require the Platform side to be in place, but I'm very confident in that, since it follows an existing pattern.

Tested that the QueryResults column is added; couldn't confirm that the role is set because the JWT overwrite of the user is a bit too aggressive, but it's at least succeeding with a `null` value.

Fixes: ENG-2473
Fixes: ENG-2475