### PR TITLE
feat: add RLS policy for query results table (ENG-2477)

### DIFF
--- a/migrations/versions/fa68605eb530_enable_rls_query_results.py
+++ b/migrations/versions/fa68605eb530_enable_rls_query_results.py
@@ -1,0 +1,41 @@
+"""Enable RLS based on the db_role for QueryResults.
+
+Revision ID: fa68605eb530
+Revises: a3a44a6c0dec
+Create Date: 2023-08-07 18:13:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "fa68605eb530"
+down_revision = "a3a44a6c0dec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE query_results ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY all_visible ON query_results
+          USING (true);
+        """
+    )
+    op.execute(
+        """
+        CREATE POLICY limited_visibility ON query_results
+          AS RESTRICTIVE
+          FOR SELECT
+          TO limited_visibility
+          USING (current_user = db_role);
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP POLICY limited_visibility on query_results")
+    op.execute("DROP POLICY all_visible on query_results")
+    op.execute("ALTER TABLE query_results DISABLE ROW LEVEL SECURITY")

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -77,6 +77,23 @@ def create_tables():
         sqlalchemy.orm.configure_mappers()
         db.create_all()
 
+        db.session.execute("ALTER TABLE query_results ENABLE ROW LEVEL SECURITY")
+        db.session.execute(
+            """
+            CREATE POLICY all_visible ON query_results
+            USING (true);
+            """
+        )
+        db.session.execute(
+            """
+            CREATE POLICY limited_visibility ON query_results
+            AS RESTRICTIVE
+            FOR SELECT
+            TO limited_visibility
+            USING (current_user = db_role);
+            """
+        )
+
         # Need to mark current DB as up to date
         stamp()
     else:


### PR DESCRIPTION
Add the row-level security policy to prevent users from seeing query results that they should not.

Tested in my sandbox with manual queries. Testing in the UI requires the `set role` portions from ENG-2474 and ENG-2476.