### PR TITLE
feat: filter query results by user db_role (ENG-2477,ENG-2476,ENG-2478)

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -360,8 +360,11 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
         ).options(load_only("id"))
 
     @classmethod
-    def get_latest(cls, data_source, query, max_age=0):
-        query_hash = gen_query_hash(query)
+    def get_latest(cls, data_source, query, max_age=0, is_hash=False):
+        if is_hash:
+            query_hash = query
+        else:
+            query_hash = gen_query_hash(query)
 
         if max_age == -1:
             query = cls.query.filter(
@@ -379,6 +382,7 @@ class QueryResult(db.Model, QueryResultPersistence, BelongsToOrgMixin):
             )
 
         return query.order_by(cls.retrieved_at.desc()).first()
+
 
     @classmethod
     def store_result(

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -5,7 +5,7 @@ import time
 from functools import reduce
 from operator import or_
 
-from flask import current_app as app, url_for, request_started
+from flask import current_app as app, url_for, request_started, request_finished
 from flask_login import current_user, AnonymousUserMixin, UserMixin
 from passlib.apps import custom_app_context as pwd_context
 from sqlalchemy.exc import DBAPIError
@@ -54,12 +54,34 @@ def update_user_active_at(sender, *args, **kwargs):
         redis_connection.hset(LAST_ACTIVE_KEY, current_user.id, int(time.time()))
 
 
+def set_db_role(sender, *args, **kwargs):
+    """
+    Check to see if the current user has a db_role assigned, and,
+    if so, set it for the session.
+    """
+    logger.info(f"Checking for DB role on user: {current_user}")
+    db_role = getattr(current_user, "db_role", None)
+    if db_role:
+        logger.info(f"Setting session DB role: {db_role}")
+        db.session.execute("SET ROLE :db_role", {"db_role": db_role})
+
+
+def reset_db_role(sender, *args, **kwargs):
+    """
+    Reset any DB role set for the current user.
+    """
+    logger.info("Resetting session DB role")
+    db.session.execute("RESET ROLE")
+
+
 def init_app(app):
     """
     A Flask extension to keep user details updates in Redis and
     sync it periodically to the database (User.details).
     """
     request_started.connect(update_user_active_at, app)
+    request_started.connect(set_db_role, app)
+    request_finished.connect(reset_db_role, app)
 
 
 class PermissionsCheckMixin(object):
@@ -397,8 +419,6 @@ class AccessPermission(GFKBase, db.Model):
 
 
 class AnonymousUser(AnonymousUserMixin, PermissionsCheckMixin):
-    db_role = None
-
     @property
     def permissions(self):
         return []
@@ -419,7 +439,6 @@ class ApiUser(UserMixin, PermissionsCheckMixin):
             self.object = api_key.object
         self.group_ids = groups
         self.org = org
-        self.db_role = None
 
     def __repr__(self):
         return "<{}>".format(self.name)

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -156,6 +156,18 @@ def serialize_query(
             for vis in query.visualizations
         ]
 
+    if getattr(current_user, "db_role", None):
+        # Override the latest_query_data_id for users with a db_role because
+        # they may not actually be able to see that one due to their db_role
+        # and may have one specific to them instead.
+        latest_result = models.QueryResult.get_latest(
+            data_source=query.data_source,
+            query=query.query_hash,
+            max_age=-1,
+            is_hash=True,
+        )
+        d["latest_query_data_id"] = latest_result and latest_result.id or None
+
     return d
 
 


### PR DESCRIPTION
If the current user has a `db_role`, they should only see query results that they have generated, so that they don't see results which contain info about resources they don't have permission to view.

Tested in my sandbox and confirmed that a user cannot see results generated by other users, can create their own results, and that those results are then visible to them.