### PR TITLE
feat: use per-user db role for query exec (ENG-2474)

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -196,6 +196,9 @@ def jwt_token_load_user_from_request(request):
 
     if not valid_token:
         return None
+    
+    if payload.get("stacklet:db_role") == "limited_visibility":
+        raise Unauthorized("Unable to determine SSO identity")
 
     # it might actually be a username or something, but it doesn't actually matter
     email = identity

--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -54,34 +54,12 @@ def update_user_active_at(sender, *args, **kwargs):
         redis_connection.hset(LAST_ACTIVE_KEY, current_user.id, int(time.time()))
 
 
-def set_db_role(sender, *args, **kwargs):
-    """
-    Check to see if the current user has a db_role assigned, and,
-    if so, set it for the session.
-    """
-    logger.info(f"Checking for DB role on user: {current_user}")
-    db_role = getattr(current_user, "db_role", None)
-    if db_role:
-        logger.info(f"Setting session DB role: {db_role}")
-        db.session.execute("SET ROLE :db_role", {"db_role": db_role})
-
-
-def reset_db_role(sender, *args, **kwargs):
-    """
-    Reset any DB role set for the current user.
-    """
-    logger.info("Resetting session DB role")
-    db.session.execute("RESET ROLE")
-
-
 def init_app(app):
     """
     A Flask extension to keep user details updates in Redis and
     sync it periodically to the database (User.details).
     """
     request_started.connect(update_user_active_at, app)
-    request_started.connect(set_db_role, app)
-    request_finished.connect(reset_db_role, app)
 
 
 class PermissionsCheckMixin(object):

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import logging
 import select
@@ -9,6 +10,7 @@ from uuid import uuid4
 import psycopg2
 from psycopg2.extras import Range
 
+from redash import settings
 from redash.query_runner import *
 from redash.utils import JSONEncoder, json_dumps, json_loads
 
@@ -238,12 +240,29 @@ class PostgreSQL(BaseSQLQueryRunner):
 
         return list(schema.values())
 
+    def _gen_role_pass(self, role_name: str) -> str:
+        """
+        Generate a password for a given role using the datasource secret and role name.
+        """
+        secret = settings.DATASOURCE_SECRET_KEY
+        return hashlib.sha256(f"{secret}:{role_name}".encode("utf-8")).hexdigest()
+
     @inject_iam_auth
-    def _get_connection(self):
+    def _get_connection(self, user):
+        if getattr(user, "db_role", None):
+            auth_config = dict(
+                user=user.db_role,
+                password=self._gen_role_pass(user.db_role),
+            )
+        else:
+            auth_config = dict(
+                user=self.configuration.get("user"),
+                password=self.configuration.get("password"),
+            )
+        logger.info(f"Connecting to datasource as {auth_config['user']}")
         self.ssl_config = _get_ssl_config(self.configuration)
         connection = psycopg2.connect(
-            user=self.configuration.get("user"),
-            password=self.configuration.get("password"),
+            **auth_config,
             host=self.configuration.get("host"),
             port=self.configuration.get("port"),
             dbname=self.configuration.get("dbname"),
@@ -254,7 +273,7 @@ class PostgreSQL(BaseSQLQueryRunner):
         return connection
 
     def run_query(self, query, user):
-        connection = self._get_connection()
+        connection = self._get_connection(user)
         _wait(connection, timeout=10)
 
         cursor = connection.cursor()


### PR DESCRIPTION
Login with per-user PG database role, if available, to ensure that RLS policies are applied to user queries. Also changes how the `redash.query_results` table is filtered, since setting the role for the entire session broke saving queries (and probably some other things) due to the rest of the entire request session losing access to all of the other Redash tables.

Depends on: https://github.com/stacklet/platform/pull/1732

Tested on my sandbox with my non-admin SSO user and manually injected account mappings. Confirmed that the user could only get query results from the `resources` table that they had an account mapping for, and that they could neither see query results generated by other users, nor directly query the `redash.query_results` table and see anything other than their own records.