### PR TITLE
fix: identity variable exception on expired token (ENG-2855)

### DIFF
--- a/redash/authentication/jwt_auth.py
+++ b/redash/authentication/jwt_auth.py
@@ -81,8 +81,9 @@ def verify_jwt_token(
     if key_id and isinstance(keys, dict):
         keys = [keys.get(key_id)]
 
-    valid_token = False
     payload = None
+    identity = None
+    valid_token = False
     any_key_valid = False
     for i, key in enumerate(keys):
         try:


### PR DESCRIPTION
Follow-up to #50, the `identity` variable should have been defined outside of the `try` block, and the fix for the expired token surfaced that bug.