### PR TITLE
fix: handle missing db_role attribute for ApiUser (ENG-3212)

### DIFF
--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -228,7 +228,7 @@ class QueryExecutor(object):
                 data,
                 run_time,
                 utcnow(),
-                self.user.db_role,
+                getattr(self.user, "db_role", None),
             )
 
             updated_query_ids = models.Query.update_latest_result(query_result)
@@ -262,7 +262,7 @@ class QueryExecutor(object):
             self.metadata.get("Queue", "unknown"),
             self.metadata.get("query_id", "unknown"),
             self.metadata.get("Username", "unknown"),
-            self.user.db_role,
+            getattr(self.user, "db_role", None),
         )
 
     def _load_data_source(self):


### PR DESCRIPTION
Public dashboard URLs use the `ApiUser` class rather than `User` which doesn't have the `db_role` attribute. We handle this in most places, but a couple got missed. This prevents public dashboards from properly refreshing their data.

Part of: [ENG-3212](https://stacklet.atlassian.net/browse/ENG-3212)

[ENG-3212]: https://stacklet.atlassian.net/browse/ENG-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ