### PR TITLE
fix: make UI redirect to console for expired auth (ENG-3278)

### DIFF
--- a/client/app/services/auth.js
+++ b/client/app/services/auth.js
@@ -105,7 +105,6 @@ export const Auth = {
   requireSession() {
     logger("Requested authentication");
     if (Auth.isAuthenticated()) {
-      notifySessionRestored();  // Stacklet: if logged in via Stacklet, handle the popup login, if present
       return Promise.resolve(session);
     }
     return Auth.loadSession()

--- a/client/app/services/auth.js
+++ b/client/app/services/auth.js
@@ -41,7 +41,7 @@ const logger = debug("redash:auth");
 const session = { loaded: false };
 
 const AuthUrls = {
-  Login: window.location.hostname.replace(/^redash\.(.*)/, "https://console.$1/?redirect=assetdb"),
+  Login: window.location.hostname.replace(/^redash\.(.*)/, "https://console.$1/?redirect=assetdb&redirectPath=" + window.location.pathname),
 };
 
 export function updateClientConfig(newClientConfig) {

--- a/client/app/services/auth.js
+++ b/client/app/services/auth.js
@@ -105,6 +105,7 @@ export const Auth = {
   requireSession() {
     logger("Requested authentication");
     if (Auth.isAuthenticated()) {
+      notifySessionRestored();  // Stacklet: if logged in via Stacklet, handle the popup login, if present
       return Promise.resolve(session);
     }
     return Auth.loadSession()

--- a/client/app/services/auth.js
+++ b/client/app/services/auth.js
@@ -41,7 +41,7 @@ const logger = debug("redash:auth");
 const session = { loaded: false };
 
 const AuthUrls = {
-  Login: window.location.hostname.replace(/^redash\.(.*)/, "https://console.$1/?redirect=assetdb&redirectPath=" + window.location.pathname),
+  Login: window.location.hostname.replace(/^redash\.(.*)/, "https://console.$1/?redirect=assetdb"),
 };
 
 export function updateClientConfig(newClientConfig) {
@@ -61,15 +61,14 @@ export const Auth = {
     return session.loaded && session.user.id;
   },
   getLoginUrl() {
-    return AuthUrls.Login;
+    return `${AuthUrls.Login}&redirectPath=${encodeURI(window.location.pathname)}`;
   },
   setLoginUrl(loginUrl) {
     AuthUrls.Login = loginUrl;
   },
   login() {
-    const next = encodeURI(location.url);
-    logger("Calling login with next = %s", next);
-    window.location.href = `${AuthUrls.Login}?next=${next}`;
+    logger("Login.");
+    window.location.href = Auth.getLoginUrl();
   },
   logout() {
     logger("Logout.");

--- a/client/app/services/auth.js
+++ b/client/app/services/auth.js
@@ -41,7 +41,7 @@ const logger = debug("redash:auth");
 const session = { loaded: false };
 
 const AuthUrls = {
-  Login: "login",
+  Login: window.location.hostname.replace(/^redash\.(.*)/, "https://console.$1/?redirect=assetdb"),
 };
 
 export function updateClientConfig(newClientConfig) {

--- a/client/app/services/restoreSession.jsx
+++ b/client/app/services/restoreSession.jsx
@@ -32,8 +32,7 @@ function showRestoreSessionPrompt(loginUrl, onSuccess) {
     content: "Your session has expired. Please login to continue.",
     okText: (
       <React.Fragment>
-        Login <i className="fa fa-external-link m-r-5" aria-hidden="true" />
-        <span className="sr-only">(opens in a new tab)</span>
+        Login <i className="fa m-r-5" aria-hidden="true" />
       </React.Fragment>
     ),
     centered: true,
@@ -56,6 +55,9 @@ function showRestoreSessionPrompt(loginUrl, onSuccess) {
         status: "yes",
       };
 
+      // Popup auth doesn't work with Stacklet login.
+      window.location.href = loginUrl;
+      /*
       popup = window.open(loginUrl, "Restore Session", map(popupOptions, (value, key) => `${key}=${value}`).join(","));
 
       const handlePostMessage = event => {
@@ -71,6 +73,7 @@ function showRestoreSessionPrompt(loginUrl, onSuccess) {
       };
 
       window.addEventListener("message", handlePostMessage, false);
+      */
     },
   });
 }


### PR DESCRIPTION
When we merged the upstream changes a while back, they included changes to how the expired login redirect worked, with it being handled more in the frontend. This updates that frontend logic to work with Stacklet auth, as well as adding support for `redirectPath` to bring you back to the specific page that you were on after logging in.

Depends on: https://github.com/stacklet/platform-ui/pull/1818

Deployed in [my sandbox](https://console.cory.sandbox.stacklet.dev/) for testing.