### PR TITLE
feat: support return redirect for unauthed links and explicit logout

### DIFF
--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 from datetime import timedelta
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote_plus, urlsplit, urlunsplit
 
 from flask import redirect, request, session, url_for
 from flask_login import LoginManager, login_user, logout_user, user_logged_in
@@ -247,7 +247,7 @@ def redirect_to_login():
         return {"message": "Couldn't find resource. Please login and try again."}, 404
 
     if org_settings["auth_jwt_login_enabled"] and org_settings["auth_jwt_auth_login_url"]:
-        login_url = org_settings["auth_jwt_auth_login_url"]
+        login_url = org_settings["auth_jwt_auth_login_url"].format(next=quote_plus(request.full_path))
     else:
         login_url = get_login_url(next=request.url, external=False)
 
@@ -261,6 +261,8 @@ def logout_and_redirect_to_index():
         index_url = "/"
     elif settings.MULTI_ORG:
         index_url = url_for("redash.index", org_slug=current_org.slug, _external=False)
+    elif org_settings["auth_jwt_login_enabled"] and org_settings["auth_jwt_auth_logout_url"]:
+        index_url = org_settings["auth_jwt_auth_logout_url"]
     else:
         index_url = url_for("redash.index", _external=False)
 

--- a/redash/authentication/__init__.py
+++ b/redash/authentication/__init__.py
@@ -261,8 +261,6 @@ def logout_and_redirect_to_index():
         index_url = "/"
     elif settings.MULTI_ORG:
         index_url = url_for("redash.index", org_slug=current_org.slug, _external=False)
-    elif org_settings["auth_jwt_login_enabled"] and org_settings["auth_jwt_auth_logout_url"]:
-        index_url = org_settings["auth_jwt_auth_logout_url"]
     else:
         index_url = url_for("redash.index", _external=False)
 

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -15,6 +15,7 @@ from redash.authentication.account import (
 )
 from redash.handlers import routes
 from redash.handlers.base import json_response, org_scoped_rule
+from redash.settings.organization import settings as org_settings
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +222,8 @@ def login(org_slug=None):
 @routes.route(org_scoped_rule("/logout"))
 def logout(org_slug=None):
     logout_user()
+    if org_settings["auth_jwt_login_enabled"] and org_settings["auth_jwt_auth_logout_url"]:
+        return redirect(org_settings["auth_jwt_auth_logout_url"])
     return redirect(get_login_url(next=None))
 
 

--- a/redash/settings/organization.py
+++ b/redash/settings/organization.py
@@ -38,6 +38,7 @@ JWT_AUTH_CLIENT_ID = os.environ.get("REDASH_JWT_AUTH_CLIENT_ID", "")
 JWT_AUTH_COOKIE_NAME = os.environ.get("REDASH_JWT_AUTH_COOKIE_NAME", "")
 JWT_AUTH_HEADER_NAME = os.environ.get("REDASH_JWT_AUTH_HEADER_NAME", "")
 JWT_AUTH_LOGIN_URL = os.environ.get("REDASH_JWT_AUTH_LOGIN_URL", "")
+JWT_AUTH_LOGOUT_URL = os.environ.get("REDASH_JWT_AUTH_LOGOUT_URL", "")
 
 FEATURE_SHOW_PERMISSIONS_CONTROL = parse_boolean(os.environ.get("REDASH_FEATURE_SHOW_PERMISSIONS_CONTROL", "false"))
 SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES = parse_boolean(
@@ -70,6 +71,7 @@ settings = {
     "auth_jwt_auth_cookie_name": JWT_AUTH_COOKIE_NAME,
     "auth_jwt_auth_header_name": JWT_AUTH_HEADER_NAME,
     "auth_jwt_auth_login_url": JWT_AUTH_LOGIN_URL,
+    "auth_jwt_auth_logout_url": JWT_AUTH_LOGOUT_URL,
     "feature_show_permissions_control": FEATURE_SHOW_PERMISSIONS_CONTROL,
     "send_email_on_failed_scheduled_queries": SEND_EMAIL_ON_FAILED_SCHEDULED_QUERIES,
     "hide_plotly_mode_bar": HIDE_PLOTLY_MODE_BAR,


### PR DESCRIPTION
Implementing ENG-3278 added support for returning to the desired page after login for existing tabs whose auth had expired, but it still doesn't work for fresh links when not authed. This also adds support for logging out via the Redash menu when using shared auth.

~~Logout portion depends on https://github.com/stacklet/platform-ui/pull/1819~~ **Edit:** This is merged.

Deployed in [my sandbox](https://console.cory.sandbox.stacklet.dev/) for testing.