### PR TITLE
fix: avoid a KeyError in outdated_queries

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -637,7 +637,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
                 if query.schedule.get("disabled"):
                     continue
 
-                if query.schedule["until"]:
+                if query.schedule.get("until"):
                     schedule_until = pytz.utc.localize(datetime.datetime.strptime(query.schedule["until"], "%Y-%m-%d"))
 
                     if schedule_until <= now:


### PR DESCRIPTION
Don't raise an exception when checking for outdated queries, if a query's schedule is missing an "until" key.

That can lead to valid queries being accidentally disabled, which we see as entries like this in the scheduled worker logs:

```console
Could not determine if query 1558 is outdated due to KeyError('until'). The schedule for this query has been disabled.
```

For the record, I could only find one other case where the code asks "do we have a non-empty value for `until`?". And [in that case](https://github.com/stacklet/redash/blob/c29ab2313f8cf610fd47a440f09eb12b28cf7bf6/redash/models/__init__.py#L617-L618), it explicitly considers that the key could be entirely missing:

```python
    def past_scheduled_queries(cls):
        now = utils.utcnow()
        queries = Query.query.filter(func.jsonb_typeof(Query.schedule) != "null").order_by(Query.id)
        return [
            query
            for query in queries
            if "until" in query.schedule
            and query.schedule["until"] is not None
            and pytz.utc.localize(datetime.datetime.strptime(query.schedule["until"], "%Y-%m-%d")) <= now
        ]
```

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
