### PR TITLE
fix: datetime-json

### DIFF
--- a/redash/models/users.py
+++ b/redash/models/users.py
@@ -35,7 +35,7 @@ def sync_last_active_at():
     user_ids = redis_connection.hkeys(LAST_ACTIVE_KEY)
     for user_id in user_ids:
         timestamp = redis_connection.hget(LAST_ACTIVE_KEY, user_id)
-        active_at = dt_from_timestamp(timestamp)
+        active_at = dt_from_timestamp(timestamp).strftime("%Y-%m-%dT%H:%M:%SZ")
         user = User.query.filter(User.id == user_id).first()
         if user:
             user.active_at = active_at


### PR DESCRIPTION
1. Then “active_at” column is never updated in the DB - due to the json serialization error of datetime.datetime.timestamp, polluting the logs
2. As a side effect Last Active At was never appearing for users under Settings > Users, the field was always empty