### PR TITLE
chore: support auth on redis (ENG-4206)

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -13,6 +13,7 @@ from redash import settings
 from redash.app import create_app  # noqa
 from redash.destinations import import_destinations
 from redash.query_runner import import_query_runners
+from redash.stacklet.auth import get_redis_auth_token
 
 __version__ = "24.05.0-dev"
 
@@ -43,8 +44,8 @@ def setup_logging():
 
 setup_logging()
 
-redis_connection = redis.from_url(settings.REDIS_URL)
-rq_redis_connection = redis.from_url(settings.RQ_REDIS_URL)
+redis_connection = redis.from_url(settings.REDIS_URL, password=get_redis_auth_token())
+rq_redis_connection = redis.from_url(settings.RQ_REDIS_URL, password=get_redis_auth_token())
 mail = Mail()
 migrate = Migrate(compare_type=True)
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)

--- a/redash/stacklet/auth.py
+++ b/redash/stacklet/auth.py
@@ -82,6 +82,15 @@ def get_db_cred_secret(dbcreds):
     return json.loads(secret["SecretString"])
 
 
+def get_redis_auth_token():
+    token_arn = os.environ.get("REDASH_REDIS_TOKEN_ARN")
+    if not token_arn:
+        return None
+    client = boto3.client("secretsmanager")
+    secret = client.get_secret_value(SecretId=token_arn)
+    return secret["SecretString"]
+
+
 def parse_iam_auth(host):
     """parse_iam_auth: parses the host and returns (True, host)
     if the iam_auth=true query parameter is found."""


### PR DESCRIPTION
Add support for AUTH on Redis.

Part of: [ENG-4206](https://stacklet.atlassian.net/browse/ENG-4206)

## Related PRs

* https://github.com/stacklet/shared-infra/pull/860
* https://github.com/stacklet/assetdb/pull/850
* https://github.com/stacklet/redash-infra/pull/207

## Testing

Deployed on my sandbox. Confirmed flush works w/o error with AUTH both required and not required.

[ENG-4206]: https://stacklet.atlassian.net/browse/ENG-4206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ