### PR TITLE
chore: refactor redis auth token handling to use container secrets

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -13,7 +13,6 @@ from redash import settings
 from redash.app import create_app  # noqa
 from redash.destinations import import_destinations
 from redash.query_runner import import_query_runners
-from redash.stacklet.auth import get_redis_auth_token
 
 __version__ = "24.05.0-dev"
 
@@ -44,8 +43,9 @@ def setup_logging():
 
 setup_logging()
 
-redis_connection = redis.from_url(settings.REDIS_URL, password=get_redis_auth_token())
-rq_redis_connection = redis.from_url(settings.RQ_REDIS_URL, password=get_redis_auth_token())
+redis_token = os.environ.get("REDASH_REDIS_TOKEN") or None
+redis_connection = redis.from_url(settings.REDIS_URL, password=redis_token)
+rq_redis_connection = redis.from_url(settings.RQ_REDIS_URL, password=redis_token)
 mail = Mail()
 migrate = Migrate(compare_type=True)
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)

--- a/redash/stacklet/auth.py
+++ b/redash/stacklet/auth.py
@@ -82,15 +82,6 @@ def get_db_cred_secret(dbcreds):
     return json.loads(secret["SecretString"])
 
 
-def get_redis_auth_token():
-    token_arn = os.environ.get("REDASH_REDIS_TOKEN_ARN")
-    if not token_arn:
-        return None
-    client = boto3.client("secretsmanager")
-    secret = client.get_secret_value(SecretId=token_arn)
-    return secret["SecretString"]
-
-
 def parse_iam_auth(host):
     """parse_iam_auth: parses the host and returns (True, host)
     if the iam_auth=true query parameter is found."""


### PR DESCRIPTION
Manually reading the secret is silly since AWS already supports indirectly passing the secret to the task via the container definition's `secrets` list, which we're already using for other things.