### PR TITLE
fix: suppress error screen on error from ResizeObserver

### DIFF
--- a/client/app/components/ApplicationArea/index.jsx
+++ b/client/app/components/ApplicationArea/index.jsx
@@ -24,6 +24,10 @@ export default function ApplicationArea() {
           `[Uncaught SyntaxError: Unexpected token '<'] usually means that a fallback html file was returned from server rather than the expected script. Check that the server is properly serving the file ${event.filename}.`
         );
       }
+      if (event.message === "ResizeObserver loop completed with undelivered notifications.") {
+        // swallowing this error until https://issues.chromium.org/issues/391393420 is resolved
+        return;
+      }
       setUnhandledError(event.error);
     }
 


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix
- [x] Other

## Description
This is a temporary hack to prevent redash rendering an error page when ResizeObserver returns the error "ResizeObserver loop completed with undelivered notifications." This is a new issue in Chrome 132 and other Chromium based browsers like Microsoft Edge. For context, see this [slack thread](https://stacklet.slack.com/archives/C02A9FTN2JV/p1737567354857929). 

As it isn't clear if this new behaviour from the ResizeObserver API is a regression, or new intended behaviour, this branch offers a temporary resolution until the [Chromium bug](https://issues.chromium.org/issues/391393420) is resolved.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually 
- [ ] N/A

Manually tested running redash locally against dev assetdb. While the runtime error can still be observed in dev, it no longer crashes and renders the redash error page, and from the user perspective fails silently.
