### PR TITLE
chore: Add "manage.py users stacklet-get-api-key" command

### DIFF
--- a/redash/cli/users.py
+++ b/redash/cli/users.py
@@ -309,3 +309,10 @@ def list_command(organization=None):
         groups = models.Group.query.filter(models.Group.id.in_(user.group_ids)).all()
         group_names = [group.name for group in groups]
         print("Groups: {}".format(", ".join(group_names)))
+
+
+@manager.command()
+@option("--user_id", type=int, required=True)
+def stacklet_get_api_token(user_id):
+    user = models.User.get_by_id(user_id)
+    print(user.api_token)


### PR DESCRIPTION
Will be used by deployment infrastructure instead of poking directly in the DB.
