### PR TITLE
fix: don't crash if selector is not set for alarm [ENG-5473]

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -1072,7 +1072,7 @@ class Alert(TimestampMixin, BelongsToOrgMixin, db.Model):
             "ALERT_NAME": self.name,
             "ALERT_URL": "{host}/alerts/{alert_id}".format(host=host, alert_id=self.id),
             "ALERT_STATUS": self.state.upper(),
-            "ALERT_SELECTOR": self.options["selector"],
+            "ALERT_SELECTOR": self.options.get("selector", "first"),
             "ALERT_CONDITION": self.options["op"],
             "ALERT_THRESHOLD": self.options["value"],
             "QUERY_NAME": self.query_rel.name,


### PR DESCRIPTION
[ENG-5473](https://stacklet.atlassian.net/browse/ENG-5473)

### what

fix a KeyError being raised when the "selector" is not present for an alarm.

### why

While the evaluate() code has a fallback to "first", the render_template()
logic is missing it. This matches the behavior.

### testing

haven't been able to reproduce the issue in my sandbox, unfortunately

### docs

n/a


[ENG-5473]: https://stacklet.atlassian.net/browse/ENG-5473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ