### PR TITLE
fix: make latest query results specific to db_role

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ x-redash-environment: &redash-environment
   REDASH_HOST: http://localhost:5001
   REDASH_LOG_LEVEL: "INFO"
   REDASH_REDIS_URL: "redis://redis:6379/0"
+  ASSETDB_DATABASE_URI: "postgresql://postgres@postgres/postgres"
   REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
   REDASH_RATELIMIT_ENABLED: "false"
   REDASH_MAIL_DEFAULT_SENDER: "redash@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
 requires-python = ">=3.8"
+name = "redash"
+version = "25.06.0-dev"
 
 [tool.black]
 target-version = ['py38']

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -79,6 +79,7 @@ def create_tables():
         sqlalchemy.orm.configure_mappers()
         db.create_all()
 
+        db.session.execute(f"SET search_path to {settings.SQLALCHEMY_DATABASE_SCHEMA}")
         db.session.execute("ALTER TABLE query_results ENABLE ROW LEVEL SECURITY")
         db.session.execute(
             """

--- a/redash/cli/database.py
+++ b/redash/cli/database.py
@@ -79,7 +79,6 @@ def create_tables():
         sqlalchemy.orm.configure_mappers()
         db.create_all()
 
-        db.session.execute(f"SET search_path to {settings.SQLALCHEMY_DATABASE_SCHEMA}")
         db.session.execute("ALTER TABLE query_results ENABLE ROW LEVEL SECURITY")
         db.session.execute(
             """

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -56,7 +56,7 @@ error_messages = {
 }
 
 
-def run_query(query, parameters, data_source, query_id, should_apply_auto_limit, max_age=0):
+def run_query(query, parameters, data_source, query_id, should_apply_auto_limit, max_age=0, db_role=None):
     if not data_source:
         return error_messages["no_data_source"]
 
@@ -81,7 +81,7 @@ def run_query(query, parameters, data_source, query_id, should_apply_auto_limit,
     if max_age == 0:
         query_result = None
     else:
-        query_result = models.QueryResult.get_latest(data_source, query_text, max_age)
+        query_result = models.QueryResult.get_latest(data_source, query_text, max_age, db_role=db_role)
 
     record_event(
         current_user.org,
@@ -274,6 +274,7 @@ class QueryResultResource(BaseResource):
                 query_id,
                 should_apply_auto_limit,
                 max_age,
+                db_role=self.current_user.db_role,
             )
         else:
             if not query.parameterized.is_safe:

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -185,6 +185,7 @@ class QueryResultListResource(BaseResource):
             query_id,
             should_apply_auto_limit,
             max_age,
+            db_role=getattr(self.current_user, "db_role", None),
         )
 
 
@@ -274,7 +275,7 @@ class QueryResultResource(BaseResource):
                 query_id,
                 should_apply_auto_limit,
                 max_age,
-                db_role=self.current_user.db_role,
+                db_role=getattr(self.current_user, "db_role", None),
             )
         else:
             if not query.parameterized.is_safe:

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -348,7 +348,7 @@ class QueryResult(db.Model, BelongsToOrgMixin):
         )
 
     @classmethod
-    def get_latest(cls, data_source, query, max_age=0, is_hash=False):
+    def get_latest(cls, data_source, query, max_age=0, is_hash=False, db_role=None):
         if is_hash:
             query_hash = query
         else:
@@ -363,6 +363,7 @@ class QueryResult(db.Model, BelongsToOrgMixin):
             query = cls.query.filter(
                 cls.query_hash == query_hash,
                 cls.data_source == data_source,
+                cls.db_role == db_role,
                 (
                     db.func.timezone("utc", cls.retrieved_at) + datetime.timedelta(seconds=max_age)
                     >= db.func.timezone("utc", db.func.now())

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -358,12 +358,16 @@ class QueryResult(db.Model, BelongsToOrgMixin):
             max_age = settings.QUERY_RESULTS_EXPIRED_TTL
 
         if max_age == -1:
-            query = cls.query.filter(cls.query_hash == query_hash, cls.data_source == data_source)
+            query = cls.query.filter(
+                cls.query_hash == query_hash,
+                cls.data_source == data_source,
+                cls.db_role.is_(None) if db_role is None else (cls.db_role == db_role),
+            )
         else:
             query = cls.query.filter(
                 cls.query_hash == query_hash,
                 cls.data_source == data_source,
-                cls.db_role == db_role,
+                cls.db_role.is_(None) if db_role is None else (cls.db_role == db_role),
                 (
                     db.func.timezone("utc", cls.retrieved_at) + datetime.timedelta(seconds=max_age)
                     >= db.func.timezone("utc", db.func.now())

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -126,14 +126,6 @@ def serialize_query(
     else:
         d["last_modified_by_id"] = query.last_modified_by_id
 
-    if with_stats:
-        if query.latest_query_data is not None:
-            d["retrieved_at"] = query.retrieved_at
-            d["runtime"] = query.runtime
-        else:
-            d["retrieved_at"] = None
-            d["runtime"] = None
-
     if with_visualizations:
         d["visualizations"] = [serialize_visualization(vis, with_query=False) for vis in query.visualizations]
 
@@ -149,6 +141,10 @@ def serialize_query(
         db_role=getattr(current_user, "db_role", None),
     )
     d["latest_query_data_id"] = latest_result and latest_result.id or None
+
+    if with_stats:
+        d["retrieved_at"] = latest_result and latest_result.retrieved_at or None
+        d["runtime"] = latest_result and latest_result.runtime or None
 
     return d
 

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -129,22 +129,37 @@ def serialize_query(
     if with_visualizations:
         d["visualizations"] = [serialize_visualization(vis, with_query=False) for vis in query.visualizations]
 
-    # Override the latest_query_data_id to use results matching the active
-    # user's db_role. This ensures that users with full row-level access
-    # get complete result sets, and users with restrictions only get result
-    # sets with those same restrictions applied.
-    latest_result = models.QueryResult.get_latest(
-        data_source=query.data_source,
-        query=query.query_hash,
-        max_age=-1,
-        is_hash=True,
-        db_role=getattr(current_user, "db_role", None),
-    )
-    d["latest_query_data_id"] = latest_result and latest_result.id or None
-
     if with_stats:
-        d["retrieved_at"] = latest_result and latest_result.retrieved_at or None
-        d["runtime"] = latest_result and latest_result.runtime or None
+        # If we're serializing queries with stats, we can show last run
+        # data even if it's not specific to the current user's db_role.
+        # The downside is that the latest run may come from another
+        # permission level, but the upside is that we don't need to
+        # fetch latest runs on demand for each query.
+        #
+        # This affects API paths such like:
+        # - /api/queries
+        # - /api/queries/my
+        # - /api/queries/favorites
+        d["retrieved_at"] = query.latest_query_data and query.retrieved_at or None
+        d["runtime"] = query.latest_query_data and query.runtime or None
+    else:
+        # When we're _not_ fetching stats, we care more about the details
+        # of a latest run. This affects API paths like:
+        #
+        # - /api/queries/<query_id>
+        #
+        # Override the latest_query_data_id to use results matching the active
+        # user's db_role. This ensures that users with full row-level access
+        # get complete result sets, and users with restrictions only get result
+        # sets with those same restrictions applied.
+        latest_result = models.QueryResult.get_latest(
+            data_source=query.data_source,
+            query=query.query_hash,
+            max_age=-1,
+            is_hash=True,
+            db_role=getattr(current_user, "db_role", None),
+        )
+        d["latest_query_data_id"] = latest_result and latest_result.id or None
 
     return d
 

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -137,17 +137,18 @@ def serialize_query(
     if with_visualizations:
         d["visualizations"] = [serialize_visualization(vis, with_query=False) for vis in query.visualizations]
 
-    if getattr(current_user, "db_role", None):
-        # Override the latest_query_data_id for users with a db_role because
-        # they may not actually be able to see that one due to their db_role
-        # and may have one specific to them instead.
-        latest_result = models.QueryResult.get_latest(
-            data_source=query.data_source,
-            query=query.query_hash,
-            max_age=-1,
-            is_hash=True,
-        )
-        d["latest_query_data_id"] = latest_result and latest_result.id or None
+    # Override the latest_query_data_id to use results matching the active
+    # user's db_role. This ensures that users with full row-level access
+    # get complete result sets, and users with restrictions only get result
+    # sets with those same restrictions applied.
+    latest_result = models.QueryResult.get_latest(
+        data_source=query.data_source,
+        query=query.query_hash,
+        max_age=-1,
+        is_hash=True,
+        db_role=getattr(current_user, "db_role", None),
+    )
+    d["latest_query_data_id"] = latest_result and latest_result.id or None
 
     return d
 

--- a/tests/models/test_query_results.py
+++ b/tests/models/test_query_results.py
@@ -48,6 +48,17 @@ class QueryResultTest(BaseTestCase):
 
         self.assertEqual(found_query_result.id, qr.id)
 
+    def test_get_latest_returns_results_per_db_role(self):
+        before = utcnow() - datetime.timedelta(seconds=30)
+        qr = self.factory.create_query_result(retrieved_at=before)
+        limited_role_qr = self.factory.create_query_result(db_role='limited')
+
+        default_role_latest_results = models.QueryResult.get_latest(qr.data_source, qr.query_text, 60)
+        limited_role_latest_results = models.QueryResult.get_latest(qr.data_source, qr.query_text, 60, db_role="limited")
+
+        self.assertEqual(qr.id, default_role_latest_results.id)
+        self.assertEqual(limited_role_qr.id, limited_role_latest_results.id)
+
     def test_get_latest_returns_the_last_cached_result_for_negative_ttl(self):
         yesterday = utcnow() + datetime.timedelta(days=-100)
         self.factory.create_query_result(retrieved_at=yesterday)


### PR DESCRIPTION
[ENG-5525](https://stacklet.atlassian.net/browse/ENG-5525)

### what

Make sure that the latest query results are specific to the current user's `db_role`.

### why

Aegon encountered an issue where users with limited access were running queries, and then admins were seeing those limited cached results instead of the full result set.

### testing

This change doesn't affect which query results a user can see, or which cached results come back for a limited visibility user. The _only_ impact should be when a non-limited (admin) user tries to fetch the latest cached results for a query - they'll be guaranteed to see only non-limited (admin) cached results.

To validate that I...

- Set up 3 users with 3 different db_roles in my sandbox: limited, limited2, and admin (`None`)
- Refreshed a test query 3 times, with these results:
  - Limited user --> query result 52012
  - Admin user --> query result 52013
  - Limited2 user --> query result 52017
- Issued a series of GET requests for the test query, with these results (gist: only the admin response changes):

```
limited response from local: 52012
limited response from ajsbx: 52012
limited2 response from local: 52017
limited2 response from ajsbx: 52017
admin response from local: 52013
admin response from ajsbx: 52017
```
- Tested fetching each query result using each test user, with these results (gist: this PR changes nothing):

```
limited role fetching limited results from local: HTTP 200 response, row count: 0
limited role fetching limited results from ajsbx: HTTP 200 response, row count: 0
limited2 role fetching limited results from local: HTTP 404 response, row count: N/A
limited2 role fetching limited results from ajsbx: HTTP 404 response, row count: N/A
admin role fetching limited results from local: HTTP 200 response, row count: 0
admin role fetching limited results from ajsbx: HTTP 200 response, row count: 0
limited role fetching limited2 results from local: HTTP 404 response, row count: N/A
limited role fetching limited2 results from ajsbx: HTTP 404 response, row count: N/A
limited2 role fetching limited2 results from local: HTTP 200 response, row count: 0
limited2 role fetching limited2 results from ajsbx: HTTP 200 response, row count: 0
admin role fetching limited2 results from local: HTTP 200 response, row count: 0
admin role fetching limited2 results from ajsbx: HTTP 200 response, row count: 0
limited role fetching admin results from local: HTTP 404 response, row count: N/A
limited role fetching admin results from ajsbx: HTTP 404 response, row count: N/A
limited2 role fetching admin results from local: HTTP 404 response, row count: N/A
limited2 role fetching admin results from ajsbx: HTTP 404 response, row count: N/A
admin role fetching admin results from local: HTTP 200 response, row count: 25756
admin role fetching admin results from ajsbx: HTTP 200 response, row count: 25756
```

### docs

n/a

[ENG-5525]: https://stacklet.atlassian.net/browse/ENG-5525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ