### PR TITLE
fix: Ensure alembic_version table is in the right schema

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -46,7 +46,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(url=url, version_table_schema=schema)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -81,6 +81,7 @@ def run_migrations_online():
         connection=connection,
         target_metadata=target_metadata,
         process_revision_directives=process_revision_directives,
+        version_table_schema=schema,
         **current_app.extensions["migrate"].configure_args
     )
 


### PR DESCRIPTION
This previously worked accidentally because shared-infra configured us to run as the redash user in the redash schema, so PostgreSQL's default search_path of "$user, public" DTRT. But when run as a different user, alembic tried to look for alembic_version in public.