### PR TITLE
fix: make query results API resource db_role-aware

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -322,7 +322,8 @@ class QueryResultResource(BaseResource):
                 # query.latest_query_data_id isn't db_role-specific, so
                 # ignore it and fetch the latest results for the current
                 # user's role.
-                query_result = models.QueryResult.get_latest(
+                query_result = get_object_or_404(
+                    models.QueryResult.get_latest,
                     data_source=query.data_source,
                     query=query.query_hash,
                     max_age=-1,

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -318,11 +318,16 @@ class QueryResultResource(BaseResource):
         if query_id is not None:
             query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
 
-            if query_result is None and query is not None and query.latest_query_data_id is not None:
-                query_result = get_object_or_404(
-                    models.QueryResult.get_by_id_and_org,
-                    query.latest_query_data_id,
-                    self.current_org,
+            if query_result is None and query is not None:
+                # query.latest_query_data_id isn't db_role-specific, so
+                # ignore it and fetch the latest results for the current
+                # user's role.
+                query_result = models.QueryResult.get_latest(
+                    data_source=query.data_source,
+                    query=query.query_hash,
+                    max_age=-1,
+                    is_hash=True,
+                    db_role=getattr(self.current_user, "db_role", None),
                 )
 
             if query is not None and query_result is not None and self.current_user.is_api_user():

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -66,18 +66,24 @@ def replace_query_parameters(query_text, params):
 def get_query_results(user, query_id, bring_from_cache, params=None):
     query = _load_query(user, query_id)
     if bring_from_cache:
-        if query.latest_query_data_id is not None:
-            results = query.latest_query_data.data
-        else:
+        results = models.QueryResult.get_latest(
+            data_source=query.data_source,
+            query=query.query_hash,
+            max_age=-1,
+            is_hash=True,
+            db_role=getattr(user, "db_role", None),
+        )
+        if not results:
             raise Exception("No cached result available for query {}.".format(query.id))
-    else:
-        query_text = query.query_text
-        if params is not None:
-            query_text = replace_query_parameters(query_text, params)
+        return results.data
 
-        results, error = query.data_source.query_runner.run_query(query_text, user)
-        if error:
-            raise Exception("Failed loading results for query id {}.".format(query.id))
+    query_text = query.query_text
+    if params is not None:
+        query_text = replace_query_parameters(query_text, params)
+
+    results, error = query.data_source.query_runner.run_query(query_text, user)
+    if error:
+        raise Exception("Failed loading results for query id {}.".format(query.id))
 
     return results
 

--- a/redash/query_runner/query_results.py
+++ b/redash/query_runner/query_results.py
@@ -206,7 +206,19 @@ class Results(BaseQueryRunner):
 
                     rows.append(dict(zip(column_names, row)))
 
-                data = {"columns": columns, "rows": rows}
+                # Track the db role associated with the cached query result.
+                # Without this we know the db_role context of the user running
+                # a query against the Query Results Data Source, but not necessarily
+                # the role of the cached query data it referenced.
+                #
+                # TODO: Potentially use this data, either as an extra check
+                #       when fetching query results or to clean up cached QRDS
+                #       results that don't specify a db_role (via migration perhaps)
+                data = {
+                    "columns": columns,
+                    "rows": rows,
+                    "db_role": getattr(user, "db_role", None),
+                }
                 error = None
             else:
                 error = "Query completed but it returned no data."


### PR DESCRIPTION
[ENG-5796](https://stacklet.atlassian.net/browse/ENG-5796)

### what

Make sure that the latest query results are specific to the current user's `db_role`, for GET requests to the direct query result endpoint:

```console
https://redash.canary.stacklet.io/api/queries/1/results.json
```

### why

Aegon encountered an issue where users with limited access were running queries, and then admins were seeing those limited cached results instead of the full result set. #77 took care of the UI driven flow from one report, but didn't address this request flow that is common for referencing cached query results in policies with robot user API keys.

### testing

Reproduced in my sandbox to verify the change interactively, and confirmed that the included unit test passes now but failed without the change. 

### docs

n/a

[ENG-5796]: https://stacklet.atlassian.net/browse/ENG-5796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure GET `api/queries/:id/results.json` returns the latest cached result for the current user's `db_role`, not the query's global `latest_query_data`.
> 
> - **Backend**:
>   - **`QueryResultResource.get`**: When fetching by `query_id` (without `query_result_id`), ignore `query.latest_query_data_id` and use `models.QueryResult.get_latest` with `db_role=getattr(self.current_user, "db_role", None)` to retrieve role-specific cached results.
> - **Tests**:
>   - Add `test_query_results_by_db_role` validating that admin and limited users receive their respective cached results for the same query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a19b166099ea2c7399e7d4a01a23525ed3e603ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->