### PR TITLE
fix: handle limited visibility for query params (ENG-6342)

### DIFF
--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -460,7 +460,14 @@ class QueryRefreshResource(BaseResource):
         parameter_values = collect_parameters_from_request(request.args)
         parameterized_query = ParameterizedQuery(query.query_text, org=self.current_org)
         should_apply_auto_limit = query.options.get("apply_auto_limit", False)
-        return run_query(parameterized_query, parameter_values, query.data_source, query.id, should_apply_auto_limit, db_role=self.current_user.db_role)
+        return run_query(
+            parameterized_query,
+            parameter_values,
+            query.data_source,
+            query.id,
+            should_apply_auto_limit,
+            db_role=getattr(self.current_user, "db_role", None),
+        )
 
 
 class QueryTagsResource(BaseResource):

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -460,7 +460,7 @@ class QueryRefreshResource(BaseResource):
         parameter_values = collect_parameters_from_request(request.args)
         parameterized_query = ParameterizedQuery(query.query_text, org=self.current_org)
         should_apply_auto_limit = query.options.get("apply_auto_limit", False)
-        return run_query(parameterized_query, parameter_values, query.data_source, query.id, should_apply_auto_limit)
+        return run_query(parameterized_query, parameter_values, query.data_source, query.id, should_apply_auto_limit, db_role=self.current_user.db_role)
 
 
 class QueryTagsResource(BaseResource):

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,12 +1,10 @@
 import unicodedata
 from urllib.parse import quote
-import logging
 
 import regex
 from flask import make_response, request
 from flask_login import current_user
 from flask_restful import abort
-from sqlalchemy.orm.exc import NoResultFound
 
 from redash import models, settings
 from redash.handlers.base import BaseResource, get_object_or_404, record_event, add_cors_headers
@@ -199,7 +197,7 @@ class QueryResultDropdownResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_access(query.data_source, current_user, view_only)
         try:
-            return dropdown_values(query_id, self.current_org)
+            return dropdown_values(query_id, self.current_org, self.current_user)
         except QueryDetachedFromDataSourceError as e:
             abort(400, message=str(e))
 
@@ -214,11 +212,7 @@ class QueryDropdownsResource(BaseResource):
             dropdown_query = get_object_or_404(models.Query.get_by_id_and_org, dropdown_query_id, self.current_org)
             require_access(dropdown_query.data_source, current_user, view_only)
 
-        try:
-            return dropdown_values(dropdown_query_id, self.current_org, db_role=getattr(self.current_user, "db_role", None))
-        except NoResultFound as e:
-            logging.error("Dropdown values not found: %s", e)
-            abort(404)
+        return dropdown_values(dropdown_query_id, self.current_org, self.current_user)
 
 class QueryResultResource(BaseResource):
     @staticmethod

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,3 +1,4 @@
+import logging
 import unicodedata
 from urllib.parse import quote
 
@@ -9,10 +10,11 @@ from flask_restful import abort
 from redash import models, settings
 from redash.handlers.base import BaseResource, get_object_or_404, record_event, add_cors_headers
 from redash.models.parameterized_query import (
+    dropdown_values,
+    DropdownSubqueryError,
     InvalidParameterError,
     ParameterizedQuery,
     QueryDetachedFromDataSourceError,
-    dropdown_values,
 )
 from redash.permissions import (
     has_access,
@@ -35,6 +37,8 @@ from redash.utils import (
     json_dumps,
     to_filename,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def error_response(message, http_status=400):
@@ -197,8 +201,9 @@ class QueryResultDropdownResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_access(query.data_source, current_user, view_only)
         try:
-            return dropdown_values(query_id, self.current_org, self.current_user)
-        except QueryDetachedFromDataSourceError as e:
+            return dropdown_values(query_id, self.current_org, self.current_user, load_on_demand=True)
+        except (DropdownSubqueryError, QueryDetachedFromDataSourceError) as e:
+            logger.exception(e)
             abort(400, message=str(e))
 
 
@@ -212,7 +217,11 @@ class QueryDropdownsResource(BaseResource):
             dropdown_query = get_object_or_404(models.Query.get_by_id_and_org, dropdown_query_id, self.current_org)
             require_access(dropdown_query.data_source, current_user, view_only)
 
-        return dropdown_values(dropdown_query_id, self.current_org, self.current_user)
+        try:
+            return dropdown_values(dropdown_query_id, self.current_org, self.current_user, load_on_demand=True)
+        except (DropdownSubqueryError, QueryDetachedFromDataSourceError) as e:
+            logger.exception(e)
+            abort(400, message=str(e))
 
 class QueryResultResource(BaseResource):
     @staticmethod

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -201,7 +201,9 @@ class QueryResultDropdownResource(BaseResource):
         query = get_object_or_404(models.Query.get_by_id_and_org, query_id, self.current_org)
         require_access(query.data_source, current_user, view_only)
         try:
-            return dropdown_values(query_id, self.current_org, self.current_user, load_on_demand=True)
+            result = dropdown_values(query_id, self.current_org, self.current_user, run_if_not_cached=True)
+            models.db.session.commit()
+            return result
         except (DropdownSubqueryError, InvalidParameterError, QueryDetachedFromDataSourceError) as e:
             logger.exception(e)
             abort(400, message=str(e))
@@ -218,7 +220,9 @@ class QueryDropdownsResource(BaseResource):
             require_access(dropdown_query.data_source, current_user, view_only)
 
         try:
-            return dropdown_values(dropdown_query_id, self.current_org, self.current_user, load_on_demand=True)
+            result = dropdown_values(dropdown_query_id, self.current_org, self.current_user, run_if_not_cached=True)
+            models.db.session.commit()
+            return result
         except (DropdownSubqueryError, InvalidParameterError, QueryDetachedFromDataSourceError) as e:
             logger.exception(e)
             abort(400, message=str(e))

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -69,7 +69,7 @@ def run_query(query, parameters, data_source, query_id, should_apply_auto_limit,
         return error_response(message)
 
     try:
-        query.apply(parameters)
+        query.apply(parameters, db_role=db_role)
     except (InvalidParameterError, QueryDetachedFromDataSourceError) as e:
         abort(400, message=str(e))
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -1,10 +1,12 @@
 import unicodedata
 from urllib.parse import quote
+import logging
 
 import regex
 from flask import make_response, request
 from flask_login import current_user
 from flask_restful import abort
+from sqlalchemy.orm.exc import NoResultFound
 
 from redash import models, settings
 from redash.handlers.base import BaseResource, get_object_or_404, record_event, add_cors_headers
@@ -212,8 +214,11 @@ class QueryDropdownsResource(BaseResource):
             dropdown_query = get_object_or_404(models.Query.get_by_id_and_org, dropdown_query_id, self.current_org)
             require_access(dropdown_query.data_source, current_user, view_only)
 
-        return dropdown_values(dropdown_query_id, self.current_org)
-
+        try:
+            return dropdown_values(dropdown_query_id, self.current_org, db_role=getattr(self.current_user, "db_role", None))
+        except NoResultFound as e:
+            logging.error("Dropdown values not found: %s", e)
+            abort(404)
 
 class QueryResultResource(BaseResource):
     @staticmethod

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -69,7 +69,7 @@ def run_query(query, parameters, data_source, query_id, should_apply_auto_limit,
         return error_response(message)
 
     try:
-        query.apply(parameters, db_role=db_role)
+        query.apply(parameters, current_user)
     except (InvalidParameterError, QueryDetachedFromDataSourceError) as e:
         abort(400, message=str(e))
 

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -202,7 +202,7 @@ class QueryResultDropdownResource(BaseResource):
         require_access(query.data_source, current_user, view_only)
         try:
             return dropdown_values(query_id, self.current_org, self.current_user, load_on_demand=True)
-        except (DropdownSubqueryError, QueryDetachedFromDataSourceError) as e:
+        except (DropdownSubqueryError, InvalidParameterError, QueryDetachedFromDataSourceError) as e:
             logger.exception(e)
             abort(400, message=str(e))
 
@@ -219,7 +219,7 @@ class QueryDropdownsResource(BaseResource):
 
         try:
             return dropdown_values(dropdown_query_id, self.current_org, self.current_user, load_on_demand=True)
-        except (DropdownSubqueryError, QueryDetachedFromDataSourceError) as e:
+        except (DropdownSubqueryError, InvalidParameterError, QueryDetachedFromDataSourceError) as e:
             logger.exception(e)
             abort(400, message=str(e))
 

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -880,7 +880,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         parameters_dict = {p["name"]: p.get("value") for p in self.parameters} if self.options else {}
         if any(parameters_dict):
             try:
-                query_text = self.parameterized.apply(parameters_dict).query
+                query_text = self.parameterized.apply(parameters_dict, self.user).query
             except InvalidParameterError as e:
                 logging.info(f"Unable to update hash for query {self.id} because of invalid parameters: {str(e)}")
             except QueryDetachedFromDataSourceError as e:

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -22,8 +22,16 @@ def _pluck_name_and_value(default_column, row):
     return {"name": row[name_column], "value": str(row[value_column])}
 
 
-def _load_result(query_id, org, user, load_on_demand):
+def _load_result(query_id, org, user, load_on_demand, query_stack=None):
     from redash import models
+
+    # Initialize query stack for cycle detection
+    if query_stack is None:
+        query_stack = set()
+
+    # Detect cycle
+    if query_id in query_stack:
+        raise ParameterizedQueryCycleError(query_id, query_stack)
 
     query = models.Query.get_by_id_and_org(query_id, org)
     db_role = getattr(user, "db_role", None)
@@ -45,7 +53,8 @@ def _load_result(query_id, org, user, load_on_demand):
         query_text = query.query_text
         parameters = {p["name"]: p.get("value") for p in query.parameters}
         if any(parameters):
-            query_text = query.parameterized.apply(parameters, user).query
+            # Add current query to stack before recursing
+            query_text = query.parameterized.apply(parameters, user, query_stack | {query_id}).query
         query_text = query.data_source.query_runner.apply_auto_limit(query_text, query.options.get("apply_auto_limit", False))
         try:
             started_at = time.time()
@@ -72,8 +81,8 @@ def _load_result(query_id, org, user, load_on_demand):
     return query_result.data
 
 
-def dropdown_values(query_id, org, user, load_on_demand=False):
-    data = _load_result(query_id, org, user, load_on_demand)
+def dropdown_values(query_id, org, user, load_on_demand=False, query_stack=None):
+    data = _load_result(query_id, org, user, load_on_demand, query_stack)
     first_column = data["columns"][0]["name"]
     pluck = partial(_pluck_name_and_value, first_column)
     return list(map(pluck, data["rows"]))
@@ -165,8 +174,8 @@ class ParameterizedQuery:
         self.query = template
         self.parameters = {}
 
-    def apply(self, parameters, user):
-        invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value, user)]
+    def apply(self, parameters, user, query_stack=None):
+        invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value, user, query_stack)]
         if invalid_parameter_names:
             raise InvalidParameterError(invalid_parameter_names)
         else:
@@ -175,7 +184,7 @@ class ParameterizedQuery:
 
         return self
 
-    def _valid(self, name, value, user):
+    def _valid(self, name, value, user, query_stack=None):
         if not self.schema:
             return True
 
@@ -202,7 +211,7 @@ class ParameterizedQuery:
             "enum": lambda value: _is_value_within_options(value, enum_options, allow_multiple_values),
             "query": lambda value: _is_value_within_options(
                 value,
-                [v["value"] for v in dropdown_values(query_id, self.org, user)],
+                [v["value"] for v in dropdown_values(query_id, self.org, user, query_stack=query_stack)],
                 allow_multiple_values,
             ),
             "date": _is_date,
@@ -260,4 +269,13 @@ class DropdownSubqueryError(Exception):
         self.error = error
         super(DropdownSubqueryError, self).__init__(
             "Error loading dropdown values for query id {} and db_role {}: {}".format(query_id, db_role, error)
+        )
+
+class ParameterizedQueryCycleError(DropdownSubqueryError):
+    def __init__(self, query_id, query_stack):
+        self.query_id = query_id
+        self.query_stack = query_stack
+        cycle_path = " -> ".join(str(qid) for qid in query_stack) + " -> " + str(query_id)
+        super(ParameterizedQueryCycleError, self).__init__(
+            "Circular dependency detected in dropdown parameter queries: {}".format(cycle_path)
         )

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -22,7 +22,7 @@ def _pluck_name_and_value(default_column, row):
     return {"name": row[name_column], "value": str(row[value_column])}
 
 
-def _load_result(query_id, org, user, load_on_demand, query_stack=None):
+def _load_result(query_id, org, user, run_if_not_cached, query_stack=None):
     from redash import models
 
     # Initialize query stack for cycle detection
@@ -47,7 +47,7 @@ def _load_result(query_id, org, user, load_on_demand, query_stack=None):
         db_role=db_role,
     )
     if not query_result:
-        if not load_on_demand:
+        if not run_if_not_cached:
             raise DropdownSubqueryError(query.id, db_role, "cached results not found")
         logger.info("Dropdown values not found for query id {} and db_role {}, running on-demand query to populate cache".format(query.id, db_role))
         query_text = query.query_text
@@ -77,12 +77,11 @@ def _load_result(query_id, org, user, load_on_demand, query_stack=None):
             utcnow(),
             db_role,
         )
-        models.db.session.commit()
     return query_result.data
 
 
-def dropdown_values(query_id, org, user, load_on_demand=False, query_stack=None):
-    data = _load_result(query_id, org, user, load_on_demand, query_stack)
+def dropdown_values(query_id, org, user, run_if_not_cached=False, query_stack=None):
+    data = _load_result(query_id, org, user, run_if_not_cached, query_stack)
     first_column = data["columns"][0]["name"]
     pluck = partial(_pluck_name_and_value, first_column)
     return list(map(pluck, data["rows"]))

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -48,7 +48,7 @@ def _load_result(query_id, org, user):
         query_text = query.query_text
         parameters = {p["name"]: p.get("value") for p in query.parameters}
         if any(parameters):
-            query_text = query.parameterized.apply(parameters, query.user).query
+            query_text = query.parameterized.apply(parameters, user).query
         query_text = query.data_source.query_runner.apply_auto_limit(query_text, query.options.get("apply_auto_limit", False))
         query_result = models.QueryResult.store_result(
             org.id,

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -7,6 +7,7 @@ from numbers import Number
 import pystache
 from dateutil.parser import parse
 from funcy import distinct
+from rq.timeouts import JobTimeoutException
 
 from redash.utils import mustache_render, utcnow
 
@@ -46,12 +47,17 @@ def _load_result(query_id, org, user, load_on_demand):
         if any(parameters):
             query_text = query.parameterized.apply(parameters, user).query
         query_text = query.data_source.query_runner.apply_auto_limit(query_text, query.options.get("apply_auto_limit", False))
-        started_at = time.time()
-        results, error = query.data_source.query_runner.run_query(query_text, user)
-        run_time = time.time() - started_at
+        try:
+            started_at = time.time()
+            results, error = query.data_source.query_runner.run_query(query_text, user)
+            run_time = time.time() - started_at
+            logger.info("On-demand query completed in {} seconds".format(run_time))
+        except JobTimeoutException:
+            raise DropdownSubqueryError(query.id, db_role, "Query exceeded Redash query execution time limit")
+        except Exception as e:
+            raise DropdownSubqueryError(query.id, db_role, str(e))
         if error:
             raise DropdownSubqueryError(query.id, db_role, error)
-        logger.info("On-demand query completed in {} seconds".format(run_time))
         query_result = models.QueryResult.store_result(
             org.id,
             query.data_source,

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -29,12 +29,13 @@ def _load_result(query_id, org, user, run_if_not_cached, query_stack=None):
     if query_stack is None:
         query_stack = set()
 
+    db_role = getattr(user, "db_role", None)
+
     # Detect cycle
     if query_id in query_stack:
-        raise ParameterizedQueryCycleError(query_id, query_stack)
+        raise ParameterizedQueryCycleError(query_id, db_role, query_stack)
 
     query = models.Query.get_by_id_and_org(query_id, org)
-    db_role = getattr(user, "db_role", None)
 
     if not query.data_source:
         raise QueryDetachedFromDataSourceError(query_id)
@@ -51,11 +52,13 @@ def _load_result(query_id, org, user, run_if_not_cached, query_stack=None):
             raise DropdownSubqueryError(query.id, db_role, "cached results not found")
         logger.info("Dropdown values not found for query id {} and db_role {}, running on-demand query to populate cache".format(query.id, db_role))
         query_text = query.query_text
-        parameters = {p["name"]: p.get("value") for p in query.parameters}
-        if any(parameters):
-            # Add current query to stack before recursing
-            query_text = query.parameterized.apply(parameters, user, query_stack | {query_id}).query
-        query_text = query.data_source.query_runner.apply_auto_limit(query_text, query.options.get("apply_auto_limit", False))
+        if query.options:
+            parameters = {p["name"]: p.get("value") for p in query.parameters}
+            if any(parameters):
+                # query_stack is used to detect cycles in dropdown parameter queries
+                query_text = query.parameterized.apply(parameters, user, query_stack | {query_id}).query
+            apply_auto_limit = query.options.get("apply_auto_limit", False)
+            query_text = query.data_source.query_runner.apply_auto_limit(query_text, apply_auto_limit)
         try:
             started_at = time.time()
             results, error = query.data_source.query_runner.run_query(query_text, user)
@@ -271,10 +274,12 @@ class DropdownSubqueryError(Exception):
         )
 
 class ParameterizedQueryCycleError(DropdownSubqueryError):
-    def __init__(self, query_id, query_stack):
+    def __init__(self, query_id, db_role, query_stack):
         self.query_id = query_id
         self.query_stack = query_stack
         cycle_path = " -> ".join(str(qid) for qid in query_stack) + " -> " + str(query_id)
         super(ParameterizedQueryCycleError, self).__init__(
-            "Circular dependency detected in dropdown parameter queries: {}".format(cycle_path)
+            query_id,
+            db_role,
+            "Circular dependency detected in dropdown parameter queries: {}".format(cycle_path),
         )

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -1,13 +1,16 @@
+import logging
 import re
+import time
 from functools import partial
 from numbers import Number
 
 import pystache
 from dateutil.parser import parse
 from funcy import distinct
-from sqlalchemy.orm.exc import NoResultFound
 
-from redash.utils import mustache_render
+from redash.utils import mustache_render, utcnow
+
+logger = logging.getLogger(__name__)
 
 
 def _pluck_name_and_value(default_column, row):
@@ -18,28 +21,45 @@ def _pluck_name_and_value(default_column, row):
     return {"name": row[name_column], "value": str(row[value_column])}
 
 
-def _load_result(query_id, org, db_role=None):
+def _load_result(query_id, org, user):
     from redash import models
 
     query = models.Query.get_by_id_and_org(query_id, org)
+    db_role = getattr(user, "db_role", None)
 
-    if query.data_source:
-        query_result = models.QueryResult.get_latest(
-            data_source=query.data_source,
-            query=query.query_hash,
-            max_age=-1,
-            is_hash=True,
-            db_role=db_role,
-        )
-        if not query_result:
-            raise NoResultFound("No cached result available for query {} with db_role {}.".format(query_id, db_role))
-        return query_result.data
-    else:
+    if not query.data_source:
         raise QueryDetachedFromDataSourceError(query_id)
 
+    query_result = models.QueryResult.get_latest(
+        data_source=query.data_source,
+        query=query.query_hash,
+        max_age=-1,
+        is_hash=True,
+        db_role=db_role,
+    )
+    if not query_result:
+        logger.info("Dropdown values not found for query id {} and db_role {}, running on-demand query to populate cache".format(query.id, db_role))
+        started_at = time.time()
+        results, error = query.data_source.query_runner.run_query(query.query_text, user)
+        run_time = time.time() - started_at
+        if error:
+            raise Exception("Failed loading results for query id {}: {}".format(query.id, error))
+        logger.info("On-demand query completed in {} seconds".format(run_time))
+        query_result = models.QueryResult.store_result(
+            org,
+            query.data_source,
+            query.query_hash,
+            query.query_text,
+            results,
+            run_time,
+            utcnow(),
+            db_role,
+        )
+    return query_result.data
 
-def dropdown_values(query_id, org, db_role=None):
-    data = _load_result(query_id, org, db_role)
+
+def dropdown_values(query_id, org, user):
+    data = _load_result(query_id, org, user)
     first_column = data["columns"][0]["name"]
     pluck = partial(_pluck_name_and_value, first_column)
     return list(map(pluck, data["rows"]))
@@ -131,8 +151,8 @@ class ParameterizedQuery:
         self.query = template
         self.parameters = {}
 
-    def apply(self, parameters, db_role=None):
-        invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value, db_role)]
+    def apply(self, parameters, user):
+        invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value, user)]
         if invalid_parameter_names:
             raise InvalidParameterError(invalid_parameter_names)
         else:
@@ -141,7 +161,7 @@ class ParameterizedQuery:
 
         return self
 
-    def _valid(self, name, value, db_role=None):
+    def _valid(self, name, value, user):
         if not self.schema:
             return True
 
@@ -168,7 +188,7 @@ class ParameterizedQuery:
             "enum": lambda value: _is_value_within_options(value, enum_options, allow_multiple_values),
             "query": lambda value: _is_value_within_options(
                 value,
-                [v["value"] for v in dropdown_values(query_id, self.org, db_role)],
+                [v["value"] for v in dropdown_values(query_id, self.org, user)],
                 allow_multiple_values,
             ),
             "date": _is_date,

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -46,7 +46,7 @@ def _load_result(query_id, org, user):
             raise Exception("Failed loading results for query id {}: {}".format(query.id, error))
         logger.info("On-demand query completed in {} seconds".format(run_time))
         query_result = models.QueryResult.store_result(
-            org,
+            org.id,
             query.data_source,
             query.query_hash,
             query.query_text,

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -21,7 +21,7 @@ def _pluck_name_and_value(default_column, row):
     return {"name": row[name_column], "value": str(row[value_column])}
 
 
-def _load_result(query_id, org, user):
+def _load_result(query_id, org, user, load_on_demand):
     from redash import models
 
     query = models.Query.get_by_id_and_org(query_id, org)
@@ -38,18 +38,20 @@ def _load_result(query_id, org, user):
         db_role=db_role,
     )
     if not query_result:
+        if not load_on_demand:
+            raise DropdownSubqueryError(query.id, db_role, "cached results not found")
         logger.info("Dropdown values not found for query id {} and db_role {}, running on-demand query to populate cache".format(query.id, db_role))
-        started_at = time.time()
-        results, error = query.data_source.query_runner.run_query(query.query_text, user)
-        run_time = time.time() - started_at
-        if error:
-            raise Exception("Failed loading results for query id {}: {}".format(query.id, error))
-        logger.info("On-demand query completed in {} seconds".format(run_time))
         query_text = query.query_text
         parameters = {p["name"]: p.get("value") for p in query.parameters}
         if any(parameters):
             query_text = query.parameterized.apply(parameters, user).query
         query_text = query.data_source.query_runner.apply_auto_limit(query_text, query.options.get("apply_auto_limit", False))
+        started_at = time.time()
+        results, error = query.data_source.query_runner.run_query(query_text, user)
+        run_time = time.time() - started_at
+        if error:
+            raise DropdownSubqueryError(query.id, db_role, error)
+        logger.info("On-demand query completed in {} seconds".format(run_time))
         query_result = models.QueryResult.store_result(
             org.id,
             query.data_source,
@@ -64,8 +66,8 @@ def _load_result(query_id, org, user):
     return query_result.data
 
 
-def dropdown_values(query_id, org, user):
-    data = _load_result(query_id, org, user)
+def dropdown_values(query_id, org, user, load_on_demand=False):
+    data = _load_result(query_id, org, user, load_on_demand)
     first_column = data["columns"][0]["name"]
     pluck = partial(_pluck_name_and_value, first_column)
     return list(map(pluck, data["rows"]))
@@ -243,4 +245,13 @@ class QueryDetachedFromDataSourceError(Exception):
         self.query_id = query_id
         super(QueryDetachedFromDataSourceError, self).__init__(
             "This query is detached from any data source. Please select a different query."
+        )
+
+class DropdownSubqueryError(Exception):
+    def __init__(self, query_id, db_role, error):
+        self.query_id = query_id
+        self.db_role = db_role
+        self.error = error
+        super(DropdownSubqueryError, self).__init__(
+            "Error loading dropdown values for query id {} and db_role {}: {}".format(query_id, db_role, error)
         )

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -32,7 +32,7 @@ def _load_result(query_id, org, db_role=None):
             db_role=db_role,
         )
         if not query_result:
-            raise NoResultFound("No cached result available for query {}.".format(query_id))
+            raise NoResultFound("No cached result available for query {} with db_role {}.".format(query_id, db_role))
         return query_result.data
     else:
         raise QueryDetachedFromDataSourceError(query_id)

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -45,16 +45,22 @@ def _load_result(query_id, org, user):
         if error:
             raise Exception("Failed loading results for query id {}: {}".format(query.id, error))
         logger.info("On-demand query completed in {} seconds".format(run_time))
+        query_text = query.query_text
+        parameters = {p["name"]: p.get("value") for p in query.parameters}
+        if any(parameters):
+            query_text = query.parameterized.apply(parameters, query.user).query
+        query_text = query.data_source.query_runner.apply_auto_limit(query_text, query.options.get("apply_auto_limit", False))
         query_result = models.QueryResult.store_result(
             org.id,
             query.data_source,
             query.query_hash,
-            query.query_text,
+            query_text,
             results,
             run_time,
             utcnow(),
             db_role,
         )
+        models.db.session.commit()
     return query_result.data
 
 

--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -5,6 +5,7 @@ from numbers import Number
 import pystache
 from dateutil.parser import parse
 from funcy import distinct
+from sqlalchemy.orm.exc import NoResultFound
 
 from redash.utils import mustache_render
 
@@ -17,20 +18,28 @@ def _pluck_name_and_value(default_column, row):
     return {"name": row[name_column], "value": str(row[value_column])}
 
 
-def _load_result(query_id, org):
+def _load_result(query_id, org, db_role=None):
     from redash import models
 
     query = models.Query.get_by_id_and_org(query_id, org)
 
     if query.data_source:
-        query_result = models.QueryResult.get_by_id_and_org(query.latest_query_data_id, org)
+        query_result = models.QueryResult.get_latest(
+            data_source=query.data_source,
+            query=query.query_hash,
+            max_age=-1,
+            is_hash=True,
+            db_role=db_role,
+        )
+        if not query_result:
+            raise NoResultFound("No cached result available for query {}.".format(query_id))
         return query_result.data
     else:
         raise QueryDetachedFromDataSourceError(query_id)
 
 
-def dropdown_values(query_id, org):
-    data = _load_result(query_id, org)
+def dropdown_values(query_id, org, db_role=None):
+    data = _load_result(query_id, org, db_role)
     first_column = data["columns"][0]["name"]
     pluck = partial(_pluck_name_and_value, first_column)
     return list(map(pluck, data["rows"]))
@@ -122,8 +131,8 @@ class ParameterizedQuery:
         self.query = template
         self.parameters = {}
 
-    def apply(self, parameters):
-        invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value)]
+    def apply(self, parameters, db_role=None):
+        invalid_parameter_names = [key for (key, value) in parameters.items() if not self._valid(key, value, db_role)]
         if invalid_parameter_names:
             raise InvalidParameterError(invalid_parameter_names)
         else:
@@ -132,7 +141,7 @@ class ParameterizedQuery:
 
         return self
 
-    def _valid(self, name, value):
+    def _valid(self, name, value, db_role=None):
         if not self.schema:
             return True
 
@@ -159,7 +168,7 @@ class ParameterizedQuery:
             "enum": lambda value: _is_value_within_options(value, enum_options, allow_multiple_values),
             "query": lambda value: _is_value_within_options(
                 value,
-                [v["value"] for v in dropdown_values(query_id, self.org)],
+                [v["value"] for v in dropdown_values(query_id, self.org, db_role)],
                 allow_multiple_values,
             ),
             "date": _is_date,

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -56,7 +56,7 @@ def _apply_default_parameters(query):
     parameters = {p["name"]: p.get("value") for p in query.parameters}
     if any(parameters):
         try:
-            return query.parameterized.apply(parameters).query
+            return query.parameterized.apply(parameters, query.user).query
         except InvalidParameterError as e:
             error = f"Skipping refresh of {query.id} because of invalid parameters: {str(e)}"
             track_failure(query, error)


### PR DESCRIPTION
[ENG-6342](https://stacklet.atlassian.net/browse/ENG-6342)

What
----

- Make query dropdown parameters honor the limited visibility user role when looking for cached results.

Why
---

- Previously cached results for a given user were being masked by results by other users, making it seem like there were no results and forcing a new refresh every time.

Testing
-------

- [x] Deploy to [my sandbox](https://console.cory.sandbox.stacklet.dev/)
- [x] Test with the [Test - Resource Count](https://redash.cory.sandbox.stacklet.dev/queries/1?p_accountId=All&p_groups=%5B%221c57149e-e6e3-4d62-80e9-5906a2b5bd96%22%5D) query
  - [x] Confirm non-admin user can see dropdown values
  - [x] Refresh dropdown queries with admin user
  - [x] Confirm non-admin user can *still* see dropdown values
  - [x] Confirm non-admin user that has not run dropdown queries nor Test - Resource Count query will still see dropdown values and query results (after short delay due to running the query) upon loading the page

Docs
----

Update `NEWS.md` in `redash-infra`.


[ENG-6342]: https://stacklet.atlassian.net/browse/ENG-6342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ