### PR TITLE
chore: fetch stacklet app config from ssm (ENG-6500)

### DIFF
--- a/redash/handlers/__init__.py
+++ b/redash/handlers/__init__.py
@@ -32,6 +32,7 @@ def init_app(app):
         organization,
         queries,
         setup,
+        stacklet,
         static,
     )
 

--- a/redash/handlers/stacklet.py
+++ b/redash/handlers/stacklet.py
@@ -1,11 +1,12 @@
+from flask_login import login_required
 from redash.handlers import routes
 from redash.handlers.base import json_response
 from redash.security import talisman
 from redash.stacklet.config import get_application_config
 
-
 @routes.route("/stacklet/config", methods=["GET"])
 @talisman(force_https=False)
+@login_required
 def stacklet_config():
     """Endpoint to expose application configuration from AWS SSM Parameter Store."""
     config = get_application_config()

--- a/redash/handlers/stacklet.py
+++ b/redash/handlers/stacklet.py
@@ -1,0 +1,12 @@
+from redash.handlers import routes
+from redash.handlers.base import json_response
+from redash.security import talisman
+from redash.stacklet.config import get_application_config
+
+
+@routes.route("/stacklet/config", methods=["GET"])
+@talisman(force_https=False)
+def stacklet_config():
+    """Endpoint to expose application configuration from AWS SSM Parameter Store."""
+    config = get_application_config()
+    return json_response(config)

--- a/redash/handlers/stacklet.py
+++ b/redash/handlers/stacklet.py
@@ -1,3 +1,4 @@
+import functools
 from flask_login import login_required
 from redash.handlers import routes
 from redash.handlers.base import json_response
@@ -7,6 +8,7 @@ from redash.stacklet.config import get_application_config
 @routes.route("/stacklet/config", methods=["GET"])
 @talisman(force_https=False)
 @login_required
+@functools.cache
 def stacklet_config():
     """Endpoint to expose application configuration from AWS SSM Parameter Store."""
     config = get_application_config()

--- a/redash/handlers/stacklet.py
+++ b/redash/handlers/stacklet.py
@@ -1,4 +1,3 @@
-import functools
 from flask_login import login_required
 from redash.handlers import routes
 from redash.handlers.base import json_response
@@ -8,7 +7,6 @@ from redash.stacklet.config import get_application_config
 @routes.route("/stacklet/config", methods=["GET"])
 @talisman(force_https=False)
 @login_required
-@functools.cache
 def stacklet_config():
     """Endpoint to expose application configuration from AWS SSM Parameter Store."""
     config = get_application_config()

--- a/redash/stacklet/config.py
+++ b/redash/stacklet/config.py
@@ -1,0 +1,38 @@
+import json
+import logging
+import os
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+def get_application_config():
+    """Fetches application config from SSM Parameter Store.
+
+    Reads the STACKLET_PREFIX environment variable and fetches
+    /stacklet/{prefix}/application-config from AWS SSM Parameter Store.
+
+    Returns:
+        dict: The application configuration as a JSON object
+    """
+    stacklet_prefix = os.environ.get("STACKLET_PREFIX") or "dev"
+    region = os.environ.get("AWS_REGION")
+    param_name = f"/stacklet/{stacklet_prefix}/application-config"
+
+    logger.info(
+        f"Fetching SSM parameter: {param_name} from region: {region} (prefix: {stacklet_prefix})"
+    )
+
+    client = boto3.client("ssm", region_name=region)
+
+    try:
+        response = client.get_parameter(Name=param_name, WithDecryption=True)
+        logger.info(f"Successfully fetched parameter: {param_name}")
+        # Parse the parameter value as JSON
+        return json.loads(response["Parameter"]["Value"])
+    except Exception as e:
+        logger.error(
+            f"Failed to fetch SSM parameter. Name: {param_name}, Region: {region}, "
+            f"STACKLET_PREFIX env: {stacklet_prefix}, Error: {str(e)}"
+        )
+        raise

--- a/redash/stacklet/config.py
+++ b/redash/stacklet/config.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import os
@@ -6,6 +7,7 @@ import boto3
 logger = logging.getLogger(__name__)
 
 
+@functools.cache
 def get_application_config():
     """Fetches application config from SSM Parameter Store.
 


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
Add handler for route /stacklet/config to make application config available to the redash client (needed for app urls)

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
https://stacklet.atlassian.net/browse/ENG-6500

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
