### PR TITLE
chore: the default branch for this repo is `stacklet/integration`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
                   - type: "section"
                     text:
                       type: "mrkdwn"
-                      text: ${{ toJSON(github.ref_name == 'main' && 'Branch: main' || format('Branch: ⚠️  {0}', github.ref_name)) }}
+                      text: ${{ toJSON(github.ref_name == 'stacklet/integration' && 'Branch: stacklet/integration' || format('Branch: ⚠️  {0}', github.ref_name)) }}
                   - type: "divider"
                   - type: "section"
                     text:
@@ -77,7 +77,7 @@ jobs:
                   - type: "section"
                     text:
                       type: "mrkdwn"
-                      text: ${{ toJSON(github.ref_name == 'main' && 'Branch: main' || format('Branch: ⚠️  {0}', github.ref_name)) }}
+                      text: ${{ toJSON(github.ref_name == 'stacklet/integration' && 'Branch: stacklet/integration' || format('Branch: ⚠️  {0}', github.ref_name)) }}
                   - type: "divider"
                   - type: "section"
                     text:


### PR DESCRIPTION
### what

Updated the e2e-tests workflow Slack notification logic to treat
`stacklet/integration` as the primary branch instead of `main`. Two
occurrences in `.github/workflows/e2e-tests.yml` were updated — one in
the success notification and one in the failure notification — so that
runs on `stacklet/integration` report cleanly, while runs on any other
branch are flagged with a warning emoji.

### why

This repo's default/main branch is `stacklet/integration`, not
`main`. The existing check caused every run on `stacklet/integration` to
be incorrectly flagged as a non-primary-branch run in Slack
notifications.

### testing

CI workflow change; correctness is verified by observing that the next
e2e-tests run on `stacklet/integration` produces an unwarned branch
label in the Slack notification.

### docs

No documentation changes required.