### PR TITLE
fix: avoid spurious filter resets from concurrent loadDashboard calls

### DIFF
--- a/client/app/pages/dashboards/hooks/useDashboard.js
+++ b/client/app/pages/dashboards/hooks/useDashboard.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { isEmpty, includes, compact, map, has, pick, keys, extend, every, get } from "lodash";
+import { isEmpty, includes, compact, map, has, pick, keys, extend, every, get, isEqual } from "lodash";
 import notification from "@/services/notification";
 import location from "@/services/location";
 import url from "@/services/url";
@@ -138,7 +138,7 @@ function useDashboard(dashboardData) {
       return Promise.all(loadWidgetPromises).then(() => {
         const queryResults = compact(map(dashboardRef.current.widgets, widget => widget.getQueryResult()));
         const updatedFilters = collectDashboardFilters(dashboardRef.current, queryResults, location.search);
-        setFilters(updatedFilters);
+        setFilters(prevFilters => (isEqual(prevFilters, updatedFilters) ? prevFilters : updatedFilters));
       });
     },
     [loadWidget]


### PR DESCRIPTION
### what

In `useDashboard.js`, changed `setFilters(updatedFilters)` to a
functional update that preserves the existing state reference when
filter values are unchanged (using `lodash.isEqual`).

### why

The failing e2e test `Dashboard Filters > filters rows in a Table
Visualization` exposed a race condition introduced by the axios 0.30.x /
werkzeug 3.x upgrade (PR #88), which shifted request-completion timing.

On dashboard mount, two `useEffect` hooks independently call
`loadDashboard()`. Each call resolves its widget promises and calls
`setFilters(collectDashboardFilters(...))`. `collectDashboardFilters`
always returns a **new array reference** even when filter values are
identical. Each new reference triggers a `useEffect` in
`VisualizationRenderer` that calls `combineFilters(localFilters,
globalFilters)`, resetting any user-modified local filter selection back
to the global default.

With the new timing, this reset was firing **after** the test clicked a
filter option, causing the widget to display 4 rows instead of the
expected 3.

By preserving the existing reference when values are unchanged, spurious
effect triggers in `VisualizationRenderer` are suppressed, and local
filter selections survive concurrent `loadDashboard()` completions.

### testing

Covered by the existing Cypress e2e test
`client/cypress/integration/dashboard/filters_spec.js` — specifically
`Dashboard Filters > filters rows in a Table Visualization`.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)