### PR TITLE
chore: re-query before clicks to prevent detached-DOM flakiness

### DIFF
--- a/client/cypress/integration/dashboard/dashboard_tags_spec.js
+++ b/client/cypress/integration/dashboard/dashboard_tags_spec.js
@@ -12,9 +12,8 @@ describe("Dashboard Tags", () => {
 
     cy.getByTestId("TagsControl").contains(".label", "Unpublished");
 
-    cy.getByTestId("EditTagsButton")
-      .should("contain", "Add tag")
-      .click();
+    cy.getByTestId("EditTagsButton").should("contain", "Add tag");
+    cy.getByTestId("EditTagsButton").click();
 
     typeInTagsSelectAndSave("tag1{enter}tag2{enter}tag3{enter}");
 

--- a/client/cypress/integration/query/create_query_spec.js
+++ b/client/cypress/integration/query/create_query_spec.js
@@ -14,9 +14,8 @@ describe("Create Query", () => {
       .get(".ace_text-input")
       .type("SELECT id, name FROM organizations{esc}", { force: true });
 
-    cy.getByTestId("ExecuteButton")
-      .should("be.enabled")
-      .click();
+    cy.getByTestId("ExecuteButton").should("be.enabled");
+    cy.getByTestId("ExecuteButton").click();
 
     cy.getByTestId("TableVisualization").should("exist");
     cy.percySnapshot("Edit Query");

--- a/client/cypress/integration/query/query_tags_spec.js
+++ b/client/cypress/integration/query/query_tags_spec.js
@@ -18,9 +18,8 @@ describe("Query Tags", () => {
 
     cy.getByTestId("TagsControl").contains(".label", "Unpublished");
 
-    cy.getByTestId("EditTagsButton")
-      .should("contain", "Add tag")
-      .click();
+    cy.getByTestId("EditTagsButton").should("contain", "Add tag");
+    cy.getByTestId("EditTagsButton").click();
 
     typeInTagsSelectAndSave("tag1{enter}tag2{enter}tag3{enter}");
 

--- a/client/cypress/integration/settings/organization_settings_spec.js
+++ b/client/cypress/integration/settings/organization_settings_spec.js
@@ -22,7 +22,8 @@ describe("Settings", () => {
       query: "SELECT NOW()",
     }).then(({ id: queryId }) => {
       cy.visit(`/queries/${queryId}/source`);
-      cy.getByTestId("ExecuteButton").should("not.be.disabled").click();
+      cy.getByTestId("ExecuteButton").should("not.be.disabled");
+      cy.getByTestId("ExecuteButton").click();
 
       // "created at" field is formatted with the date format.
       cy.getByTestId("TableVisualization")

--- a/client/cypress/integration/user/logout_spec.js
+++ b/client/cypress/integration/user/logout_spec.js
@@ -8,9 +8,8 @@ describe("Logout", () => {
     cy.getByTestId("ProfileDropdown").click();
     // Wait until submenu appears and become interactive
     cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
-    cy.getByTestId("LogOutButton")
-      .should("be.visible")
-      .click();
+    cy.getByTestId("LogOutButton").should("be.visible");
+    cy.getByTestId("LogOutButton").click();
 
     cy.title().should("eq", "Login to Redash");
   });

--- a/client/cypress/integration/visualizations/box_plot_spec.js
+++ b/client/cypress/integration/visualizations/box_plot_spec.js
@@ -44,7 +44,8 @@ describe("Box Plot", () => {
       .then(({ id }) => cy.createVisualization(id, "BOXPLOT", "Boxplot (Deprecated)", {}))
       .then(({ id: visualizationId, query_id: queryId }) => {
         cy.visit(`queries/${queryId}/source#${visualizationId}`);
-        cy.getByTestId("ExecuteButton").should("not.be.disabled").click();
+        cy.getByTestId("ExecuteButton").should("not.be.disabled");
+        cy.getByTestId("ExecuteButton").click();
       });
   });
 

--- a/client/cypress/integration/visualizations/chart_spec.js
+++ b/client/cypress/integration/visualizations/chart_spec.js
@@ -33,7 +33,8 @@ describe("Chart", () => {
 
   it("creates Bar charts", function() {
     cy.visit(`queries/${this.queryId}/source`);
-    cy.getByTestId("ExecuteButton").should("not.be.disabled").click();
+    cy.getByTestId("ExecuteButton").should("not.be.disabled");
+    cy.getByTestId("ExecuteButton").click();
 
     const getBarChartAssertionFunction = (specificBarChartAssertionFn = () => {}) => () => {
       // checks for TabbedEditor standard tabs

--- a/client/cypress/integration/visualizations/choropleth_spec.js
+++ b/client/cypress/integration/visualizations/choropleth_spec.js
@@ -34,7 +34,8 @@ describe("Choropleth", () => {
     cy.login();
     cy.createQuery({ query: SQL }).then(({ id }) => {
       cy.visit(`queries/${id}/source`);
-      cy.getByTestId("ExecuteButton").should("not.be.disabled").click();
+      cy.getByTestId("ExecuteButton").should("not.be.disabled");
+      cy.getByTestId("ExecuteButton").click();
     });
     cy.getByTestId("NewVisualization").click();
     cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.CHOROPLETH");

--- a/client/cypress/integration/visualizations/cohort_spec.js
+++ b/client/cypress/integration/visualizations/cohort_spec.js
@@ -24,7 +24,8 @@ describe("Cohort", () => {
     cy.login();
     cy.createQuery({ query: SQL }).then(({ id }) => {
       cy.visit(`queries/${id}/source`);
-      cy.getByTestId("ExecuteButton").should("not.be.disabled").click();
+      cy.getByTestId("ExecuteButton").should("not.be.disabled");
+      cy.getByTestId("ExecuteButton").click();
     });
     cy.getByTestId("NewVisualization").click();
     cy.getByTestId("VisualizationType").selectAntdOption("VisualizationType.COHORT");

--- a/client/cypress/integration/visualizations/edit_visualization_dialog_spec.js
+++ b/client/cypress/integration/visualizations/edit_visualization_dialog_spec.js
@@ -11,9 +11,8 @@ describe("Edit visualization dialog", () => {
   });
 
   it("opens New Visualization dialog", () => {
-    cy.getByTestId("NewVisualization")
-      .should("exist")
-      .click();
+    cy.getByTestId("NewVisualization").should("exist");
+    cy.getByTestId("NewVisualization").click();
     cy.getByTestId("EditVisualizationDialog").should("exist");
     // Default visualization should be selected
     cy.getByTestId("VisualizationType")

--- a/client/cypress/integration/visualizations/funnel_spec.js
+++ b/client/cypress/integration/visualizations/funnel_spec.js
@@ -25,7 +25,8 @@ describe("Funnel", () => {
     cy.login();
     cy.createQuery({ query: SQL }).then(({ id }) => {
       cy.visit(`queries/${id}/source`);
-      cy.getByTestId("ExecuteButton").should("not.be.disabled").click();
+      cy.getByTestId("ExecuteButton").should("not.be.disabled");
+      cy.getByTestId("ExecuteButton").click();
     });
   });
 

--- a/client/cypress/integration/visualizations/pivot_spec.js
+++ b/client/cypress/integration/visualizations/pivot_spec.js
@@ -107,9 +107,8 @@ describe("Pivot", () => {
       cy.wait(200);
 
       cy.getByTestId("SaveButton").click();
-      cy.getByTestId("ExecuteButton")
-        .should("be.enabled")
-        .click();
+      cy.getByTestId("ExecuteButton").should("be.enabled");
+      cy.getByTestId("ExecuteButton").click();
 
       // assert number of rows is 12
       cy.getByTestId("PivotTableVisualization").contains(".pvtGrandTotal", "12");

--- a/client/cypress/integration/visualizations/table/table_spec.js
+++ b/client/cypress/integration/visualizations/table/table_spec.js
@@ -18,7 +18,8 @@ function prepareVisualization(query, type, name, options) {
       // free more space for visualizations. Also, we'll hide schema browser (via shortcut)
       cy.visit(`queries/${queryId}#${visualizationId}`);
 
-      cy.getByTestId("ExecuteButton").first().should("not.be.disabled").click();
+      cy.getByTestId("ExecuteButton").first().should("not.be.disabled");
+      cy.getByTestId("ExecuteButton").first().click();
       cy.get("body").type("{alt}D");
 
       // do some pre-checks here to ensure that visualization was created and is visible
@@ -42,8 +43,10 @@ describe("Table", () => {
     const { query, config } = AllCellTypes;
     prepareVisualization(query, "TABLE", "All cell types", config).then(() => {
       // expand JSON cell
-      cy.get(".jvi-item.jvi-root .jvi-toggle").should("be.visible").click();
-      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").should("be.visible").click({ multiple: true });
+      cy.get(".jvi-item.jvi-root .jvi-toggle").should("be.visible");
+      cy.get(".jvi-item.jvi-root .jvi-toggle").click();
+      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").should("be.visible");
+      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").click({ multiple: true });
 
       cy.percySnapshot("Visualizations - Table (All cell types)", { widths: [viewportWidth] });
     });


### PR DESCRIPTION
### what

Fix the detached-DOM anti-pattern across all Cypress e2e tests: split
every chained `.should(...).action()` call into separate queries — one
statement for the assertion, a fresh `cy.get()` for the action.

### why

When `.should()` and an action (`.click()`, `.type()`, etc.) are chained
on the same element reference, React can re-render between those two
Cypress commands, replacing the original DOM node. Cypress then tries to
act on the now-detached reference and times out.

The immediate trigger was `Table - renders all cell types` failing in CI
with `CypressError: cy.click() failed because this element is detached
from the DOM` on the `jvi-toggle` span (confirmed in CI logs).
A sweep of all spec files found the same pattern in 12 other places,
including the `LogOutButton` (inside a just-opened dropdown),
`EditTagsButton` (text-content assertion on a stateful button), the
`NewVisualization` button (after async query execution), and the
`ExecuteButton` (9 occurrences across visualization and query specs).

Re-querying with a fresh `cy.get()` before each action ensures Cypress
holds a live DOM reference and re-activates its built-in actionability
retry loop, making the interaction self-healing if a re-render occurs.

### testing

Diagnosed from CI e2e test output. Fix aligns with the standard Cypress
guidance for detached-DOM errors:
https://on.cypress.io/element-has-detached-from-dom

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)