### PR TITLE
chore: chain cy.get assertions + clicks to avoid detached-DOM flakiness

### DIFF
--- a/client/cypress/integration/user/logout_spec.js
+++ b/client/cypress/integration/user/logout_spec.js
@@ -8,8 +8,7 @@ describe("Logout", () => {
     cy.getByTestId("ProfileDropdown").click();
     // Wait until submenu appears and become interactive
     cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
-    cy.getByTestId("LogOutButton").should("be.visible");
-    cy.getByTestId("LogOutButton").click();
+    cy.getByTestId("LogOutButton").should("be.visible").click();
 
     cy.title().should("eq", "Login to Redash");
   });

--- a/client/cypress/integration/visualizations/table/table_spec.js
+++ b/client/cypress/integration/visualizations/table/table_spec.js
@@ -43,10 +43,8 @@ describe("Table", () => {
     const { query, config } = AllCellTypes;
     prepareVisualization(query, "TABLE", "All cell types", config).then(() => {
       // expand JSON cell
-      cy.get(".jvi-item.jvi-root .jvi-toggle").should("be.visible");
-      cy.get(".jvi-item.jvi-root .jvi-toggle").click();
-      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").should("be.visible");
-      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").click({ multiple: true });
+      cy.get(".jvi-item.jvi-root .jvi-toggle").should("be.visible").click();
+      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").should("be.visible").click({ multiple: true });
 
       cy.percySnapshot("Visualizations - Table (All cell types)", { widths: [viewportWidth] });
     });


### PR DESCRIPTION
### what

Chain `.should("be.visible").click()` on a single `cy.get()` call
instead of issuing a separate `cy.get()` for the assertion and another
for the interaction. Two specs affected:

- `visualizations/table/table_spec.js` — `.jvi-toggle` expand clicks
- `user/logout_spec.js` — `LogOutButton` click

### why

When assertion and interaction use separate `cy.get()` calls, a React
re-render between the two commands can replace the DOM node. Cypress
then holds a stale reference and throws:

> cy.click() failed because this element is detached from the DOM

Per https://on.cypress.io/element-has-detached-from-dom, the fix is to
re-query and interact in one chain so Cypress never holds a reference
across a potential re-render boundary. `table_spec.js` reproduced in CI
on 2026-03-14; `logout_spec.js` had the same latent pattern.

### testing

Covered by the existing Cypress e2e suite. The `table_spec.js` failure
was observed in CI and no longer reproduces with this change.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)