### PR TITLE
fix: add parse_websearch migration to prevent query search 500s

### DIFF
--- a/client/cypress/integration/query/search_query_spec.js
+++ b/client/cypress/integration/query/search_query_spec.js
@@ -1,0 +1,16 @@
+describe("Query Search", () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("finds a query by name via the search API", () => {
+    cy.createQuery({ name: "Unique Searchable Query" }).then(() => {
+      cy.request("GET", "/api/queries?q=Unique+Searchable").then(response => {
+        expect(response.status).to.equal(200);
+        expect(response.body.results.length).to.be.gte(1);
+        const match = response.body.results.find(r => r.name.includes("Unique Searchable"));
+        expect(match, "expected at least one result containing 'Unique Searchable'").to.not.be.undefined;
+      });
+    });
+  });
+});

--- a/migrations/versions/771feda96f1c_create_parse_websearch_function.py
+++ b/migrations/versions/771feda96f1c_create_parse_websearch_function.py
@@ -1,0 +1,33 @@
+"""create parse_websearch function
+
+Revision ID: 771feda96f1c
+Revises: 9e8c841d1a30
+Create Date: 2026-03-24 00:00:00.000000
+
+Not a duplicate of 7ce5925f832b. That migration created the old
+tsq_search function. The sqlalchemy-searchable version bump (Werkzeug
+3.x upgrade, #88) switched from tsq_search to parse_websearch, so this
+migration creates the new function the library now expects.
+
+7ce5925f832b has ``downgrade(): pass`` — we leave that untouched.
+If this migration is downgraded the function is dropped; 7ce5925f832b's
+no-op downgrade won't re-drop it, which is harmless.
+"""
+from alembic import op
+from sqlalchemy_searchable import sql_expressions
+
+
+# revision identifiers, used by Alembic.
+revision = '771feda96f1c'
+down_revision = '9e8c841d1a30'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(sql_expressions)
+
+
+def downgrade():
+    op.execute("DROP FUNCTION IF EXISTS parse_websearch(regconfig, text)")
+    op.execute("DROP FUNCTION IF EXISTS parse_websearch(text)")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -55,6 +55,8 @@ class BaseTestCase(TestCase):
         self.app_ctx.push()
 
         db.drop_all()
+        # Force configure_mappers so searchable DDL listeners are attached
+        db.configure_mappers()
         db.create_all()
         db.session.commit()
 

--- a/tests/handlers/test_queries.py
+++ b/tests/handlers/test_queries.py
@@ -78,6 +78,14 @@ class TestQueryResourceGet(BaseTestCase):
         self.assertEqual(len(rv.json["results"]), 1)
 
 
+class TestQuerySearchRegression(BaseTestCase):
+    def test_query_search_returns_200(self):
+        """Regression test: search must not 500 due to missing parse_websearch function."""
+        self.factory.create_query(name="Searchable Query")
+        rv = self.make_request("get", "/api/queries?q=searchable")
+        self.assertEqual(rv.status_code, 200)
+
+
 class TestQueryResourcePost(BaseTestCase):
     def test_update_query(self):
         admin = self.factory.create_admin()

--- a/tests/models/test_queries.py
+++ b/tests/models/test_queries.py
@@ -3,9 +3,27 @@ import datetime
 import mock
 import pytest
 
+from sqlalchemy import text
+
 from redash.models import Event, Group, Query, QueryResult, db
 from redash.utils import gen_query_hash, utcnow
 from tests import BaseTestCase
+
+
+class TestParseWebsearchFunction(BaseTestCase):
+    """Regression tests for PR #88: parse_websearch must exist in the database."""
+
+    def test_parse_websearch_function_exists(self):
+        result = db.session.execute(
+            text("SELECT parse_websearch('pg_catalog.simple', 'test query')")
+        ).scalar()
+        self.assertIsNotNone(result)
+
+    def test_parse_websearch_single_arg_overload(self):
+        result = db.session.execute(
+            text("SELECT parse_websearch('test query')")
+        ).scalar()
+        self.assertIsNotNone(result)
 
 
 class QueryTest(BaseTestCase):


### PR DESCRIPTION
[ENG-7077](https://stacklet.atlassian.net/browse/ENG-7077)

### what

- Add Alembic migration (`771feda96f1c`) that creates the
  `parse_websearch` SQL function via
  `sqlalchemy_searchable.sql_expressions`.
- Call `db.configure_mappers()` in test setup so searchable
  DDL listeners fire before `create_all()`.
- Add regression tests (unit + handler) verifying that the
  `parse_websearch` function exists and that
  `GET /api/queries?q=…` returns 200.
- Add Cypress e2e spec exercising query search via the API.

### why

After the Werkzeug 3.x / dependency upgrade in #88, the
`parse_websearch` function was no longer provisioned
automatically, causing `GET /api/queries?q=…` to fail with
a 500 error. The migration ensures the function exists in
all environments.

Fixes: fc0631701 ("chore: security updates including werkzeug 3.x (#88)")

### testing

- `just backend-test tests/models/test_queries.py` —
  confirms `parse_websearch` function exists (both
  overloads).
- `just backend-test tests/handlers/test_queries.py` —
  confirms search endpoint returns 200.
- Cypress spec `search_query_spec.js` covers the same
  path end-to-end.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-7077]: https://stacklet.atlassian.net/browse/ENG-7077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ