### PR TITLE
fix: make sure filename header values are strings (ENG-7091)

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -131,15 +131,13 @@ def content_disposition_filenames(attachment_filename):
     if not isinstance(attachment_filename, str):
         attachment_filename = attachment_filename.decode("utf-8")
 
-    try:
-        attachment_filename = attachment_filename.encode("ascii")
-    except UnicodeEncodeError:
+    if attachment_filename.isascii():
+        filenames = {"filename": attachment_filename}
+    else:
         filenames = {
-            "filename": unicodedata.normalize("NFKD", attachment_filename).encode("ascii", "ignore"),
+            "filename": unicodedata.normalize("NFKD", attachment_filename).encode("ascii", "ignore").decode(),
             "filename*": "UTF-8''%s" % quote(attachment_filename, safe=b""),
         }
-    else:
-        filenames = {"filename": attachment_filename}
 
     return filenames
 


### PR DESCRIPTION
This has the tweak I made in my sandbox to reproduce/confirm and test fixing Redash's download result filenames.

I haven't been able to run the Redash test suite due to deep personal failings though :-/ . (edit: checks are running during CI neato, if this is actually a useful direction I'm fine to tweak the existing content-disposition header test to catch future regressions)