### PR TITLE
fix: keep Content-Disposition filenames as str for Werkzeug 3.x

### DIFF
--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -132,11 +132,11 @@ def content_disposition_filenames(attachment_filename):
         attachment_filename = attachment_filename.decode("utf-8")
 
     try:
-        attachment_filename = attachment_filename.encode("ascii")
+        attachment_filename.encode("ascii")
     except UnicodeEncodeError:
         filenames = {
-            "filename": unicodedata.normalize("NFKD", attachment_filename).encode("ascii", "ignore"),
-            "filename*": "UTF-8''%s" % quote(attachment_filename, safe=b""),
+            "filename": unicodedata.normalize("NFKD", attachment_filename).encode("ascii", "ignore").decode("ascii"),
+            "filename*": "UTF-8''%s" % quote(attachment_filename, safe=""),
         }
     else:
         filenames = {"filename": attachment_filename}

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -1,6 +1,36 @@
-from redash.handlers.query_results import error_messages, run_query
+from redash.handlers.query_results import content_disposition_filenames, error_messages, run_query
 from redash.models import db
 from tests import BaseTestCase
+
+
+class TestContentDispositionFilenames(BaseTestCase):
+    def test_ascii_filename_returns_str(self):
+        result = content_disposition_filenames("report_2026_03_24.csv")
+        self.assertIsInstance(result["filename"], str)
+        self.assertEqual(result["filename"], "report_2026_03_24.csv")
+
+    def test_ascii_filename_has_no_filename_star(self):
+        result = content_disposition_filenames("report_2026_03_24.csv")
+        self.assertNotIn("filename*", result)
+
+    def test_unicode_filename_returns_str_values(self):
+        result = content_disposition_filenames("שלום_report.csv")
+        self.assertIsInstance(result["filename"], str)
+        self.assertIsInstance(result["filename*"], str)
+        # Hebrew characters have no ASCII equivalents, so NFKD normalisation leaves them
+        # unchanged and encode("ascii", "ignore") drops them entirely — only the ASCII
+        # suffix "_report.csv" survives.  filename* (RFC 5987 percent-encoded) is the
+        # authoritative field for non-ASCII names; filename is a degraded fallback.
+        self.assertEqual(result["filename"], "_report.csv")
+
+    def test_unicode_filename_star_is_rfc5987(self):
+        result = content_disposition_filenames("שלום_report.csv")
+        self.assertTrue(result["filename*"].startswith("UTF-8''"), result["filename*"])
+
+    def test_bytes_input_is_decoded(self):
+        result = content_disposition_filenames(b"report_2026_03_24.csv")
+        self.assertIsInstance(result["filename"], str)
+        self.assertEqual(result["filename"], "report_2026_03_24.csv")
 
 
 class TestRunQuery(BaseTestCase):


### PR DESCRIPTION
[ENG-7091](https://stacklet.atlassian.net/browse/ENG-7091)

### what

`content_disposition_filenames()` in
`redash/handlers/query_results.py` was leaving the `filename` field
of the returned dict as `bytes` in both the ASCII and non-ASCII
branches. Specifically:

- ASCII path: the result of `.encode("ascii")` was stored directly
  instead of the original `str`.
- Non-ASCII path: `.encode("ascii", "ignore")` produced `bytes` for
  the `filename` key, and `quote()` was called with `safe=b""` (a
  bytes argument).

Five unit tests are added to `TestContentDispositionFilenames` covering
the ASCII str path, ASCII bytes input, the no-`filename*` invariant for
ASCII names, the non-ASCII str-values path, and the RFC 5987
`filename*` format. A clarifying comment in the Unicode test explains
why Hebrew characters are completely absent from the degraded `filename`
fallback (no ASCII equivalents, so NFKD + `encode("ascii","ignore")`
drops them entirely).

### why

Werkzeug 3.x removed implicit coercion of bytes header values to
strings. When `bytes` were passed as the `filename` parameter of the
`Content-Disposition` header, Werkzeug serialised them using their
`repr`, producing filenames like
`b'Tagging_-_Count_By_Account_2026_03_24.csv'` on disk.

Fixes: fc0631701 ("chore: security updates including werkzeug 3.x (#88)")

### testing

- `just backend-test tests/handlers/test_query_results.py` — all tests
  pass, including five new unit tests that directly assert `str` types
  for both the ASCII and non-ASCII filename paths.
- [x] Deployed and tested on my sandbox

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-7091]: https://stacklet.atlassian.net/browse/ENG-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ