### PR TITLE
chore: fix detached-DOM flakiness in dashboard E2E tests

### DIFF
--- a/client/cypress/integration/dashboard/filters_spec.js
+++ b/client/cypress/integration/dashboard/filters_spec.js
@@ -46,7 +46,8 @@ describe("Dashboard Filters", () => {
     cy.getByTestId(this.widget1TestId).within(() => {
       expectTableToHaveLength(4);
       expectFirstColumnToHaveMembers(["a", "a", "a", "a"]);
-
+    });
+    cy.getByTestId(this.widget1TestId).within(() => {
       cy.getByTestId("FilterName-stage1::filter")
         .find(".ant-select")
         .click();

--- a/client/cypress/integration/dashboard/parameter_spec.js
+++ b/client/cypress/integration/dashboard/parameter_spec.js
@@ -62,7 +62,8 @@ describe("Dashboard Parameters", () => {
     // widget parameter mapping is the default for the API
     cy.getByTestId(this.widgetTestId).within(() => {
       cy.getByTestId("TableVisualization").should("contain", "example1");
-
+    });
+    cy.getByTestId(this.widgetTestId).within(() => {
       cy.getByTestId("ParameterName-param1")
         .find("input")
         .type("{selectall}Redash");

--- a/client/cypress/integration/dashboard/widget_spec.js
+++ b/client/cypress/integration/dashboard/widget_spec.js
@@ -209,7 +209,8 @@ describe("Widget", () => {
       cy.getByTestId(elTestId).within(() => {
         cy.getByTestId("TableVisualization").should("contain", "sleep time: 0");
         cy.get(".refresh-indicator").should("not.be.visible");
-
+      });
+      cy.getByTestId(elTestId).within(() => {
         cy.getByTestId("ParameterName-sleep-time").type("10");
         cy.getByTestId("ParameterApplyButton").click();
         cy.get(".refresh-indicator").should("be.visible");

--- a/client/cypress/integration/query/create_query_spec.js
+++ b/client/cypress/integration/query/create_query_spec.js
@@ -14,8 +14,7 @@ describe("Create Query", () => {
       .get(".ace_text-input")
       .type("SELECT id, name FROM organizations{esc}", { force: true });
 
-    cy.getByTestId("ExecuteButton").should("be.enabled");
-    cy.getByTestId("ExecuteButton").click();
+    cy.getByTestId("ExecuteButton").should("be.enabled").click();
 
     cy.getByTestId("TableVisualization").should("exist");
     cy.percySnapshot("Edit Query");

--- a/client/cypress/integration/visualizations/edit_visualization_dialog_spec.js
+++ b/client/cypress/integration/visualizations/edit_visualization_dialog_spec.js
@@ -11,8 +11,7 @@ describe("Edit visualization dialog", () => {
   });
 
   it("opens New Visualization dialog", () => {
-    cy.getByTestId("NewVisualization").should("exist");
-    cy.getByTestId("NewVisualization").click();
+    cy.getByTestId("NewVisualization").should("exist").click();
     cy.getByTestId("EditVisualizationDialog").should("exist");
     // Default visualization should be selected
     cy.getByTestId("VisualizationType")

--- a/client/cypress/integration/visualizations/table/table_spec.js
+++ b/client/cypress/integration/visualizations/table/table_spec.js
@@ -18,8 +18,7 @@ function prepareVisualization(query, type, name, options) {
       // free more space for visualizations. Also, we'll hide schema browser (via shortcut)
       cy.visit(`queries/${queryId}#${visualizationId}`);
 
-      cy.getByTestId("ExecuteButton").first().should("not.be.disabled");
-      cy.getByTestId("ExecuteButton").first().click();
+      cy.getByTestId("ExecuteButton").first().should("not.be.disabled").click();
       cy.get("body").type("{alt}D");
 
       // do some pre-checks here to ensure that visualization was created and is visible
@@ -42,9 +41,9 @@ describe("Table", () => {
   it("renders all cell types", () => {
     const { query, config } = AllCellTypes;
     prepareVisualization(query, "TABLE", "All cell types", config).then(() => {
-      // expand JSON cell
-      cy.get(".jvi-item.jvi-root .jvi-toggle").should("be.visible").click();
-      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").should("be.visible").click({ multiple: true });
+      // expand JSON cell - omit should("be.visible") to avoid detached-DOM retry loop on re-renders
+      cy.get(".jvi-item.jvi-root .jvi-toggle").click();
+      cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").click({ multiple: true });
 
       cy.percySnapshot("Visualizations - Table (All cell types)", { widths: [viewportWidth] });
     });


### PR DESCRIPTION
### what

Four sets of Cypress spec changes across six files:

1. Split combined `within()` blocks — where slow assertions preceded
   clicks — into two separate blocks in three dashboard specs:
   - `dashboard/filters_spec.js`
   - `dashboard/widget_spec.js`
   - `dashboard/parameter_spec.js`

2. Chain the remaining assert-then-click pairs that `a757a58c4` had
   split into two separate `cy.get()` calls but `3838ff15b` missed:
   - `query/create_query_spec.js`
   - `visualizations/edit_visualization_dialog_spec.js`
   - `visualizations/table/table_spec.js` (`prepareVisualization`)

3. In `table_spec.js` "renders all cell types": remove the
   `.should("be.visible")` guard before clicking `.jvi-toggle`
   elements entirely, relying on `.click()`'s built-in
   actionability checks instead.

4. (All paths are under `client/cypress/integration/`.)

### why

Two distinct failure modes, both causing "element detached from DOM":

**`within()` context goes stale** — when slow or retrying assertions
share a `within()` block with a subsequent click, React can
re-render the widget before the click fires. The DOM node captured
as the `within()` context becomes an orphaned subtree; interactions
never reach the live element, and post-interaction assertions time
out after 20 s. Fix: split into two `within()` blocks so Cypress
re-queries the container before each interaction.

**Infinite retry loop on the JSON viewer** — the `jvi-toggle`
element is owned by a React component that re-renders on every
Cypress observation cycle. With `.should("be.visible").click()`,
Cypress retries the full chain each time `.click()` finds a
detached element: `get()` → `should()` passes → `click()` fails
→ repeat until the 20 s timeout. Neither the split-query approach
(a757a58c4) nor the chained approach (3838ff15b) breaks the loop
because both keep the assertion that triggers the re-render.
Dropping `.should("be.visible")` stops the cycle; `.click()` is
already actionability-checked (visible + attached + enabled).

The tests pass locally because the stale-DOM window is too short
to matter; failures appear on slower GitHub Actions runners.

Fixes: 3838ff15b ("chore: chain cy.get assertions + clicks to
avoid detached-DOM flakiness (#97)")

### testing

All changes are in test files. Verified by the CI E2E suite
(`just e2e-test`) passing the affected specs without the 20 s
timeout failure seen in the `Table / renders all cell types` test.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)