### PR TITLE
chore: restore cy.wait(500) to fix table jvi-toggle detached-DOM

### DIFF
--- a/client/cypress/integration/visualizations/table/table_spec.js
+++ b/client/cypress/integration/visualizations/table/table_spec.js
@@ -41,7 +41,10 @@ describe("Table", () => {
   it("renders all cell types", () => {
     const { query, config } = AllCellTypes;
     prepareVisualization(query, "TABLE", "All cell types", config).then(() => {
-      // expand JSON cell - omit should("be.visible") to avoid detached-DOM retry loop on re-renders
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500); // let layout settle after {alt}D hides the schema browser before clicking jvi-toggle
+
+      // expand JSON cell
       cy.get(".jvi-item.jvi-root .jvi-toggle").click();
       cy.get(".jvi-item.jvi-root .jvi-item .jvi-toggle").click({ multiple: true });
 


### PR DESCRIPTION
### what

Restores `cy.wait(500)` (with eslint-disable comment) in the
`"renders all cell types"` test in `table_spec.js`, immediately
before the clicks on `.jvi-item.jvi-root .jvi-toggle`.

### why

`cy.get("body").type("{alt}D")` hides the schema browser, causing a
layout change that makes the Ant Design virtualized table re-measure
and re-render its rows — including the jvi JSON cells. During this
settling period the `.jvi-toggle` elements are continuously replaced,
so any `cy.get().click()` (with or without a `should()` assertion)
enters Cypress's 20-second retry loop and times out.

The 500 ms wait gives the layout time to finish settling. The
original code had this wait with an explanatory comment; it was
removed in #87 in favour of `should("be.visible").click()`, which
started a sequence of increasingly elaborate workarounds, none of
which addressed the underlying cause:

- #96 split assert and click into separate `cy.get()` calls — still
  retry-looped.
- #97 chained them — still retry-looped (the jvi special-case
  described in project memory).
- #101 removed `should("be.visible")` — still retry-looped because
  `cy.click()` also retries from `cy.get()` on detachment.

Fixes: fb7a1b255 ("chore: fixes to make e2e-tests work and run them in a daily CI job (#87)")

### testing

Observed failure in CI run:

    CypressError: Timed out retrying after 20050ms: `cy.click()`
    failed because this element is detached from the DOM.
    Spec: visualizations/table/table_spec.js — "renders all cell types"

Fix will be verified by the next scheduled E2E run.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)