### PR TITLE
chore: sync Dockerfile with redash-infra, stripping build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,28 @@ RUN /etc/poetry/bin/poetry install --only $install_groups $POETRY_OPTIONS && \
 COPY --chown=redash . /app
 COPY --from=frontend-builder --chown=redash /frontend/client/dist /app/client/dist
 RUN chown redash /app
+
+# Remove build-only packages to reduce CVE surface area.
+# Re-install the runtime .so counterparts explicitly so autoremove doesn't orphan them.
+RUN SUDO_FORCE_REMOVE=yes apt-get remove -y --purge \
+      build-essential g++ pkg-config git-core git curl gnupg unzip pwgen sudo \
+      libffi-dev libssl-dev libpq-dev default-libmysqlclient-dev \
+      freetds-dev libsasl2-dev libkrb5-dev unixodbc-dev \
+      patch \
+      libcurl3-gnutls libldap-2.5-0 libnghttp2-14 \
+      perl perl-modules-5.36 libperl5.36 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libpq5 \
+      libmariadb3 \
+      libct4 \
+      libsybdb5 \
+      libgssapi-krb5-2 \
+      libodbc2 && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /etc/poetry
+
 USER redash
 
 ENTRYPOINT ["/app/bin/docker-entrypoint"]


### PR DESCRIPTION
### what

Sync Dockerfile with the copy in redash-infra.

Adds a `RUN` layer at the end of the final Docker image stage that:

- Removes build-only packages (`build-essential`, compilers, dev
  headers, `git`, `curl`, `sudo`, `patch`, etc.) and their
  Poetry-managed deps (`/etc/poetry`).
- Explicitly re-installs the runtime `.so` counterparts that would
  otherwise be orphaned by autoremove (`libpq5`, `libmariadb3`,
  `libct4`, `libsybdb5`, `libgssapi-krb5-2`, `libodbc2`).
- Runs `apt-get autoremove` and clears apt lists.

### why

Build tooling shipped in the production image widens the CVE attack
surface unnecessarily. Removing compiler toolchains, dev headers, and
utilities like `curl`/`sudo`/`git` after the build phase closes a
meaningful number of known vulnerabilities without affecting runtime
behaviour.

### testing

Built the image locally and confirmed:

- The test suite still passes
- `grype` output shows reduced vulnerability count compared to the
  unstripped image.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)