### PR TITLE
fix: UTC times not being localized (ENG-7514)

### DIFF
--- a/client/app/components/queries/__snapshots__/ScheduleDialog.test.js.snap
+++ b/client/app/components/queries/__snapshots__/ScheduleDialog.test.js.snap
@@ -1157,7 +1157,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
   data-testid="time"
 >
   <TimeEditor
-    defaultValue={"2000-01-01T20:15:00.000Z"}
+    defaultValue={"1999-12-31T22:15:00.000Z"}
     onChange={[Function]}
   >
     <TimePicker
@@ -1165,14 +1165,14 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
       format="HH:mm"
       minuteStep={5}
       onChange={[Function]}
-      value={"2000-01-01T20:15:00.000Z"}
+      value={"1999-12-31T22:15:00.000Z"}
     >
       <TimePicker
         allowClear={false}
         format="HH:mm"
         minuteStep={5}
         onChange={[Function]}
-        value={"2000-01-01T20:15:00.000Z"}
+        value={"1999-12-31T22:15:00.000Z"}
       >
         <LocaleReceiver
           componentName="DatePicker"
@@ -1301,7 +1301,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
               />
             }
             transitionName="slide-up"
-            value={"2000-01-01T20:15:00.000Z"}
+            value={"1999-12-31T22:15:00.000Z"}
           >
             <InnerPicker
               allowClear={false}
@@ -1434,7 +1434,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
                 />
               }
               transitionName="slide-up"
-              value={"2000-01-01T20:15:00.000Z"}
+              value={"1999-12-31T22:15:00.000Z"}
             >
               <PickerTrigger
                 popupElement={
@@ -1574,7 +1574,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
                       }
                       tabIndex={-1}
                       transitionName="slide-up"
-                      value={"2000-01-01T20:15:00.000Z"}
+                      value={"1999-12-31T22:15:00.000Z"}
                     />
                   </div>
                 }
@@ -1797,7 +1797,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
                         }
                         tabIndex={-1}
                         transitionName="slide-up"
-                        value={"2000-01-01T20:15:00.000Z"}
+                        value={"1999-12-31T22:15:00.000Z"}
                       />
                     </div>
                   }
@@ -1938,7 +1938,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "1 Day 22:15" Set
       data-testid="utc"
     >
       (
-      20:15
+      22:15
        UTC)
     </span>
   </TimeEditor>
@@ -4251,7 +4251,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
   data-testid="time"
 >
   <TimeEditor
-    defaultValue={"2000-01-01T20:15:00.000Z"}
+    defaultValue={"1999-12-31T22:15:00.000Z"}
     onChange={[Function]}
   >
     <TimePicker
@@ -4259,14 +4259,14 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
       format="HH:mm"
       minuteStep={5}
       onChange={[Function]}
-      value={"2000-01-01T20:15:00.000Z"}
+      value={"1999-12-31T22:15:00.000Z"}
     >
       <TimePicker
         allowClear={false}
         format="HH:mm"
         minuteStep={5}
         onChange={[Function]}
-        value={"2000-01-01T20:15:00.000Z"}
+        value={"1999-12-31T22:15:00.000Z"}
       >
         <LocaleReceiver
           componentName="DatePicker"
@@ -4395,7 +4395,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
               />
             }
             transitionName="slide-up"
-            value={"2000-01-01T20:15:00.000Z"}
+            value={"1999-12-31T22:15:00.000Z"}
           >
             <InnerPicker
               allowClear={false}
@@ -4528,7 +4528,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
                 />
               }
               transitionName="slide-up"
-              value={"2000-01-01T20:15:00.000Z"}
+              value={"1999-12-31T22:15:00.000Z"}
             >
               <PickerTrigger
                 popupElement={
@@ -4668,7 +4668,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
                       }
                       tabIndex={-1}
                       transitionName="slide-up"
-                      value={"2000-01-01T20:15:00.000Z"}
+                      value={"1999-12-31T22:15:00.000Z"}
                     />
                   </div>
                 }
@@ -4891,7 +4891,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
                         }
                         tabIndex={-1}
                         transitionName="slide-up"
-                        value={"2000-01-01T20:15:00.000Z"}
+                        value={"1999-12-31T22:15:00.000Z"}
                       />
                     </div>
                   }
@@ -5032,7 +5032,7 @@ exports[`ScheduleDialog Sets correct schedule settings Sets to "2 Weeks 22:15 Tu
       data-testid="utc"
     >
       (
-      20:15
+      22:15
        UTC)
     </span>
   </TimeEditor>

--- a/client/app/lib/utils.js
+++ b/client/app/lib/utils.js
@@ -47,16 +47,11 @@ export function formatDate(value) {
 
 export function localizeTime(time) {
   const [hrs, mins] = time.split(":");
-  // moment.locale() called with no param returns a locale ID string,
-  // but when called with a locale ID string it returns a date value.
-  // Call it first with no param to get the default locale ID and then
-  // explicitly pass that in to avoid a type error below.
-  const locale = moment.locale() || "en";
   return moment
     .utc()
     .hour(hrs)
     .minute(mins)
-    .locale(locale)
+    .local()
     .format("HH:mm");
 }
 


### PR DESCRIPTION
[ENG-7514](https://stacklet.atlassian.net/browse/ENG-7514)

What
----

- Revert cdc581a and change `.locale()` back to `.local()` in `localizeTime()`

Why
---

- This appears to be a rebase or merge conflict regression:
  1. 1e157e4 / a0a1e0a changed `local()` to `locale()` (but they're not the same; `locale()` sets the language locale, and `local()` localizes to the local time zone)
  2. 5972912 reverted it but somehow doesn't seem to have been in place when b2e279b later landed to fix an issue with the `locale()` version
  3. cdc581a seems to be the rebase squash of those and ends up re-introducing the change from `local()` to `locale()` because of the conflict between the previous two commits
- The visibile outcome of this is that the time in the query schedule dialog drifts due to repeatedly being convert to UTC but not back again

Testing
-------

- [x] Deploy to my sandbox
- [x] Verify query schedule time behavior works as expected

### Before
<img width="455" height="388" alt="image" src="https://github.com/user-attachments/assets/541bc1f8-2a74-4b50-8906-0808591e0a2e" />

**After saving again:**

<img width="455" height="388" alt="image" src="https://github.com/user-attachments/assets/7921f4d1-c121-4d19-8cde-249112506ac9" />

### After
<img width="455" height="388" alt="image" src="https://github.com/user-attachments/assets/e7fcf406-885d-49ca-95d8-86662e6d7938" />

**After saving again:**

<img width="455" height="388" alt="image" src="https://github.com/user-attachments/assets/42bced03-8caf-4c67-bb34-e2f7e469e55f" />

Docs
----

N/A


[ENG-7514]: https://stacklet.atlassian.net/browse/ENG-7514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ