### PR TITLE
chore: drop Jun0 from the AppSwitcher dropdown

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/AppSwitcher.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/AppSwitcher.jsx
@@ -49,7 +49,6 @@ export default function AppSwitcher() {
 
         const appConfigs = [
           { key: "console", label: "Console" },
-          { key: "jun0", label: "Jun0" },
           { key: "sinistral", label: "IaC Governance" },
         ];
 


### PR DESCRIPTION
### what

Removes the `jun0` entry from the AppSwitcher's `appConfigs` list
so it no longer appears in the inter-app dropdown.

### why

Jun0 has been folded into the main Stacklet Console

### testing

- [ ] tested on my sandbox

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)