### PR TITLE
feat: add AssetDB (Preview) entry to the app switcher (ENG-8329)

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/AppSwitcher.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/AppSwitcher.jsx
@@ -48,6 +48,7 @@ export default function AppSwitcher() {
         ];
 
         const appConfigs = [
+          { key: "superset", label: "AssetDB v2" },
           { key: "console", label: "Console" },
           { key: "sinistral", label: "IaC Governance" },
         ];

--- a/client/app/components/ApplicationArea/ApplicationLayout/AppSwitcher.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/AppSwitcher.jsx
@@ -48,7 +48,8 @@ export default function AppSwitcher() {
         ];
 
         const appConfigs = [
-          { key: "superset", label: "AssetDB v2" },
+          // "(Preview)" disambiguates from this Redash-backed AssetDB
+          { key: "superset", label: "AssetDB (Preview)" },
           { key: "console", label: "Console" },
           { key: "sinistral", label: "IaC Governance" },
         ];


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description

Adds an **AssetDB (Preview)** entry (Superset) to the `AppSwitcher` dropdown, keyed
on the `superset` key already served by `/stacklet/config` and skipped when unset.
From Redash's own switcher the Redash-backed AssetDB is always present, so the
Superset entry always carries the "(Preview)" suffix here.

## How is this tested?

- [x] N/A

Two-line addition, gated by the same `isValidUrl` check as the other entries.

## Related Tickets & Documents

[ENG-8329](https://stacklet.atlassian.net/browse/ENG-8329)

[ENG-8329]: https://stacklet.atlassian.net/browse/ENG-8329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
